### PR TITLE
feat: Add initial scrapers for provincial data sources

### DIFF
--- a/backend/models/licitacion.py
+++ b/backend/models/licitacion.py
@@ -28,7 +28,14 @@ class LicitacionBase(BaseModel):
 
 class LicitacionCreate(LicitacionBase):
     """Model for creating a new licitación"""
-    pass
+    id_licitacion: str = Field(..., description="Unique identifier for the licitación from the source")
+    jurisdiccion: str = Field(..., description="Jurisdiction of the licitación")
+    tipo_procedimiento: str = Field(..., description="Type of procedure for the licitación")
+    tipo_acceso: Optional[str] = Field(None, description="Type of access for the licitación")
+    municipios_cubiertos: Optional[str] = Field(None, description="Municipalities covered by the licitación")
+    fecha_scraping: Optional[datetime] = Field(None, description="Date when the licitación was scraped")
+    provincia: Optional[str] = Field(None, description="Province (specific to municipal sources)")
+    cobertura: Optional[str] = Field(None, description="Coverage (specific to aggregator sources)")
 
 
 class LicitacionUpdate(BaseModel):

--- a/backend/scrapers/buenos_aires_provincia_scraper.py
+++ b/backend/scrapers/buenos_aires_provincia_scraper.py
@@ -1,0 +1,243 @@
+from typing import Optional, List, Any
+from datetime import datetime
+import logging
+
+from pydantic import HttpUrl
+
+from backend.models.licitacion import LicitacionCreate
+from backend.scrapers.base_scraper import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+class BuenosAiresProvinciaScraper(BaseScraper):
+    """
+    Scraper for the 'Buenos Aires Provincia' data source.
+    This scraper is designed to fetch data from the provincial API.
+    """
+
+    def __init__(self):
+        super().__init__(source_name="Buenos Aires Provincia")
+        # TODO: Initialize with the actual base API URL if known
+        # self.base_url = "YOUR_API_BASE_URL_HERE" 
+
+    async def extract_licitacion_data(self, data: Any, source_url: str) -> Optional[LicitacionCreate]:
+        """
+        Extracts licitación data from an API response item.
+        
+        Args:
+            data: A dictionary representing a single licitación item from the API response.
+            source_url: The URL from which this data item was fetched (could be a detail URL or the main API URL).
+            
+        Returns:
+            A LicitacionCreate object or None if data extraction fails.
+        """
+        logger.info(f"Attempting to extract data for source_url: {source_url}")
+        if not isinstance(data, dict):
+            logger.error("Input data is not a dictionary. Cannot extract licitacion details.")
+            logger.error("API details (endpoint, parameters, response structure) are needed for BuenosAiresProvinciaScraper.")
+            return None
+
+        # Placeholder: Assume direct mapping for some fields and log for others.
+        # Actual implementation will depend on the API response structure.
+        try:
+            # Essential fields based on the prompt
+            id_licitacion = data.get("id_licitacion_api") # Assuming API field name
+            titulo = data.get("titulo_api") # Assuming API field name
+            organismo = data.get("organismo_api") 
+            jurisdiccion = data.get("jurisdiccion_api")
+            fecha_publicacion_str = data.get("fecha_publicacion_api")
+            numero_licitacion = data.get("numero_licitacion_api")
+            estado_licitacion = data.get("estado_licitacion_api")
+            monto_estimado_str = data.get("monto_estimado_api")
+            # url_fuente_api = data.get("url_fuente_api") # This might be the same as source_url or a specific detail link
+
+            # Additional fields based on the prompt
+            tipo_procedimiento = data.get("tipo_procedimiento_api")
+            tipo_acceso = data.get("tipo_acceso_api")
+            municipios_cubiertos = data.get("municipios_cubiertos_api")
+            # fecha_scraping will be set at the time of scraping, typically not from the source API directly for this field.
+            
+            # --- Data type conversions ---
+            publication_date = None
+            if fecha_publicacion_str:
+                try:
+                    publication_date = datetime.fromisoformat(fecha_publicacion_str) # Adjust format if needed
+                except ValueError:
+                    logger.warning(f"Could not parse fecha_publicacion_str: {fecha_publicacion_str}")
+                    # Optionally, try other formats or set to None
+
+            budget = None
+            if monto_estimado_str:
+                try:
+                    budget = float(str(monto_estimado_str).replace(",", ".")) # Handle potential commas
+                except ValueError:
+                    logger.warning(f"Could not parse monto_estimado_str: {monto_estimado_str}")
+
+            # --- Field Validations (Example) ---
+            if not all([id_licitacion, titulo, organismo, jurisdiccion, fecha_publicacion_str, numero_licitacion, estado_licitacion, tipo_procedimiento]):
+                logger.warning(f"Missing one or more required fields in API data for {id_licitacion or 'Unknown ID'}. Data: {data}")
+                # Depending on requirements, might return None or proceed with partial data.
+                # For now, let's assume these are critical for creating a Licitacion record.
+                # If any of these specific fields are missing, we might consider the record incomplete.
+                # However, the LicitacionCreate model itself has `title`, `organization`, `publication_date` as mandatory from Base.
+                # `id_licitacion`, `jurisdiccion`, `tipo_procedimiento` are mandatory in LicitacionCreate.
+
+            # Mapping to LicitacionCreate model
+            # Note: Some fields like `description` are not explicitly mapped here due to missing API field names in the prompt.
+            # These would need to be added once the API structure is known.
+            
+            licitacion_data = LicitacionCreate(
+                id_licitacion=str(id_licitacion) if id_licitacion else "ID_UNKNOWN", # Placeholder if missing
+                title=str(titulo) if titulo else "TITLE_UNKNOWN",
+                organization=str(organismo) if organismo else "ORG_UNKNOWN",
+                jurisdiccion=str(jurisdiccion) if jurisdiccion else "JURISDICCION_UNKNOWN",
+                publication_date=publication_date if publication_date else datetime.now(), # Placeholder
+                licitacion_number=str(numero_licitacion) if numero_licitacion else "NUM_LIC_UNKNOWN",
+                status=str(estado_licitacion) if estado_licitacion else "STATUS_UNKNOWN",
+                budget=budget,
+                source_url=HttpUrl(source_url), # Use the provided source_url
+                tipo_procedimiento=str(tipo_procedimiento) if tipo_procedimiento else "TIPO_PROC_UNKNOWN",
+                # Optional fields from LicitacionCreate
+                tipo_acceso=str(tipo_acceso) if tipo_acceso else None,
+                municipios_cubiertos=str(municipios_cubiertos) if municipios_cubiertos else None,
+                fecha_scraping=datetime.now(), # Set current time for scraping date
+                # Fields from LicitacionBase that might also come from API
+                # description=data.get("descripcion_api"),
+                # opening_date=...,
+                # expiration_date=...,
+                # etc.
+            )
+            logger.info(f"Successfully extracted and mapped data for id_licitacion: {licitacion_data.id_licitacion}")
+            return licitacion_data
+
+        except Exception as e:
+            logger.error(f"Error extracting licitacion data: {e} for data: {data}")
+            logger.error("Actual API response structure is needed to correctly implement field mapping.")
+            return None
+
+    async def extract_links(self, data: Any) -> List[str]:
+        """
+        Extracts links to individual licitación details from an API list response.
+        
+        Args:
+            data: The API response (expected to be a list or contain a list of items).
+            
+        Returns:
+            A list of URLs or unique identifiers for detail items.
+        """
+        logger.info("Attempting to extract links.")
+        logger.warning("Placeholder implementation for extract_links. API details are needed.")
+        logger.warning("Assuming API returns a list of items, and each item might have a 'detail_url' or 'id'.")
+        
+        links = []
+        if isinstance(data, list): # Assuming the API returns a list of licitaciones
+            for item in data:
+                if isinstance(item, dict):
+                    # Option 1: If items have a direct URL to their details
+                    detail_url = item.get("detail_url_api") 
+                    if detail_url and isinstance(detail_url, str):
+                        links.append(detail_url)
+                    # Option 2: If items have an ID that can be used to construct a detail URL
+                    # item_id = item.get("id_licitacion_api")
+                    # if item_id:
+                    #     links.append(f"{self.base_url}/licitaciones/{item_id}") # Example
+            logger.info(f"Extracted {len(links)} potential links (placeholder).")
+        elif isinstance(data, dict): # Assuming the API returns a dict with a list under a key like 'items'
+            items = data.get("items", []) # Placeholder key
+            for item in items:
+                 if isinstance(item, dict):
+                    detail_url = item.get("detail_url_api")
+                    if detail_url and isinstance(detail_url, str):
+                        links.append(detail_url)
+            logger.info(f"Extracted {len(links)} potential links from dict structure (placeholder).")
+        else:
+            logger.error("API response format for links not recognized (expected list or dict with 'items').")
+
+        if not links:
+            logger.info("No links extracted. This might be normal if the API provides all data directly, or it indicates an issue with API understanding.")
+        return links
+
+    async def get_next_page_url(self, data: Any, current_url: str) -> Optional[str]:
+        """
+        Determines the URL for the next page of results from an API response.
+        
+        Args:
+            data: The current API response.
+            current_url: The URL that yielded the current response.
+            
+        Returns:
+            The URL for the next page, or None if there is no next page.
+        """
+        logger.info(f"Attempting to determine next page URL from current_url: {current_url}")
+        logger.warning("Placeholder implementation for get_next_page_url. API pagination details are needed.")
+        
+        # Placeholder: Assume pagination info is in the response body
+        if isinstance(data, dict):
+            next_page_info = data.get("pagination", {}).get("next_page_url_api") # Placeholder keys
+            if next_page_info and isinstance(next_page_info, str):
+                logger.info(f"Found next page URL in API response: {next_page_info}")
+                return next_page_info
+            
+            # Alternative: Page number based pagination
+            # current_page_num = data.get("pagination", {}).get("current_page", 1)
+            # total_pages = data.get("pagination", {}).get("total_pages", 1)
+            # if current_page_num < total_pages:
+            #     # This requires knowing how to construct the next page URL (e.g., query parameter)
+            #     # For example, if current_url is "api.example.com/licitaciones?page=1"
+            #     # next_page_url = current_url.replace(f"page={current_page_num}", f"page={current_page_num + 1}")
+            #     # This is highly dependent on the API's URL structure.
+            #     logger.info(f"Calculated next page based on page number (placeholder): page {current_page_num + 1}")
+            #     # return next_page_url 
+                pass
+
+        logger.info("No next page URL found or determined (placeholder).")
+        return None
+
+# Example usage (for testing purposes, would not be part of the final scraper file usually)
+# if __name__ == '__main__':
+#     # This part would require an async environment to run properly
+#     # import asyncio
+#     scraper = BuenosAiresProvinciaScraper()
+    
+#     # Mock API data (replace with actual structure when known)
+#     mock_api_item = {
+#         "id_licitacion_api": "BAP123",
+#         "titulo_api": "Construcción Hospital Provincial",
+#         "organismo_api": "Ministerio de Salud PBA",
+#         "jurisdiccion_api": "Provincia de Buenos Aires",
+#         "fecha_publicacion_api": "2023-10-26T10:00:00Z",
+#         "numero_licitacion_api": "LIC-SALUD-001-2023",
+#         "estado_licitacion_api": "Abierta",
+#         "monto_estimado_api": "150000000.50",
+#         "tipo_procedimiento_api": "Licitación Pública",
+#         "tipo_acceso_api": "Electrónico",
+#         "municipios_cubiertos_api": "La Plata, Berisso",
+#         "descripcion_api": "Detalles de la construcción del nuevo hospital." 
+#     }
+    
+#     async def main():
+#         licitacion = await scraper.extract_licitacion_data(mock_api_item, "http://api.example.com/licitaciones/BAP123")
+#         if licitacion:
+#             print("Extracted Licitacion:")
+#             print(licitacion.model_dump_json(indent=2))
+        
+#         # Mock API list response
+#         mock_api_list = {
+#             "items": [
+#                 mock_api_item, 
+#                 {**mock_api_item, "id_licitacion_api": "BAP124", "detail_url_api": "http://api.example.com/licitaciones/BAP124"}
+#             ],
+#             "pagination": {
+#                 "current_page": 1,
+#                 "total_pages": 2,
+#                 "next_page_url_api": "http://api.example.com/licitaciones?page=2"
+#             }
+#         }
+#         links = await scraper.extract_links(mock_api_list)
+#         print(f"\nExtracted links: {links}")
+        
+#         next_page = await scraper.get_next_page_url(mock_api_list, "http://api.example.com/licitaciones?page=1")
+#         print(f"\nNext page URL: {next_page}")
+
+#     # asyncio.run(main())
+```

--- a/backend/scrapers/caba_scraper.py
+++ b/backend/scrapers/caba_scraper.py
@@ -1,0 +1,267 @@
+from typing import Optional, List, Any
+from datetime import datetime
+import logging
+
+from pydantic import HttpUrl
+from bs4 import BeautifulSoup # Added for potential HTML parsing
+
+from backend.models.licitacion import LicitacionCreate
+from backend.scrapers.base_scraper import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+class CabaScraper(BaseScraper):
+    """
+    Scraper for the 'CABA' (Ciudad Autónoma de Buenos Aires) data source.
+    This scraper is designed to be adaptable for fetching data from an API or HTML content.
+    """
+
+    def __init__(self):
+        super().__init__(source_name="CABA")
+        # TODO: Initialize with the actual base URL if known (for API or website)
+        # self.base_url = "YOUR_CABA_SOURCE_URL_HERE"
+
+    async def extract_licitacion_data(self, data: Any, source_url: str) -> Optional[LicitacionCreate]:
+        """
+        Extracts licitación data from an API response item or HTML content.
+        
+        Args:
+            data: A dictionary (from API) or string (HTML content) representing a single licitación.
+            source_url: The URL from which this data was fetched.
+            
+        Returns:
+            A LicitacionCreate object or None if data extraction fails.
+        """
+        logger.info(f"Attempting to extract data for CABA source_url: {source_url}")
+        
+        extracted_fields = {}
+
+        if isinstance(data, dict): # Process as API data
+            logger.info("Processing CABA data as dictionary (assumed API response).")
+            # Placeholder: Assume direct mapping for some fields.
+            # Actual implementation will depend on the API response structure.
+            extracted_fields = {
+                "id_licitacion": data.get("id_licitacion_api"),
+                "titulo": data.get("titulo_api"),
+                "organismo": data.get("organismo_api"),
+                "jurisdiccion": data.get("jurisdiccion_api"),
+                "fecha_publicacion_str": data.get("fecha_publicacion_api"),
+                "numero_licitacion": data.get("numero_licitacion_api"),
+                "descripcion": data.get("descripcion_api"),
+                "estado_licitacion": data.get("estado_licitacion_api"),
+                "monto_estimado_str": data.get("monto_estimado_api"),
+                "tipo_procedimiento": data.get("tipo_procedimiento_api"),
+                "tipo_acceso": data.get("tipo_acceso_api"),
+            }
+            if not any(extracted_fields.values()): # Basic check if any data was actually extracted
+                logger.warning("CABA API data dictionary seems empty or keys don't match expected _api suffixes.")
+                logger.warning("Actual API details (endpoint, response structure) are needed for CabaScraper.")
+
+
+        elif isinstance(data, str): # Process as HTML data
+            logger.info("Processing CABA data as HTML content.")
+            logger.warning("Placeholder HTML parsing for CabaScraper. Specific selectors are needed.")
+            # soup = BeautifulSoup(data, "html.parser")
+            # Example (highly dependent on actual HTML structure):
+            # extracted_fields = {
+            #     "id_licitacion": soup.select_one("#id_element_selector")_or_none_text(),
+            #     "titulo": soup.select_one(".title_selector")_or_none_text(),
+            #     ...
+            # }
+            # For now, as it's a placeholder, we'll just log and not extract.
+            pass
+
+        else:
+            logger.error("Input data for CABA is neither a dictionary nor HTML string. Cannot extract details.")
+            logger.error("Source details (API or HTML structure) are needed for CabaScraper.")
+            return None
+
+        if not extracted_fields and isinstance(data, str): # If HTML processing was skipped
+             logger.warning("HTML processing for CABA is a placeholder. No fields extracted from HTML.")
+             logger.warning("Actual HTML structure and selectors are needed for CabaScraper.")
+             # To proceed with the rest of the logic for demonstration, we might populate with placeholder markers
+             # This helps verify the downstream model creation, but in reality, if no fields are extracted,
+             # it should likely return None earlier. For this placeholder, we'll allow it.
+
+
+        try:
+            # --- Data type conversions ---
+            publication_date = None
+            fecha_publicacion_str = extracted_fields.get("fecha_publicacion_str")
+            if fecha_publicacion_str:
+                try:
+                    publication_date = datetime.fromisoformat(str(fecha_publicacion_str)) # Adjust format if needed
+                except (ValueError, TypeError):
+                    logger.warning(f"Could not parse fecha_publicacion_str for CABA: {fecha_publicacion_str}")
+
+            budget = None
+            monto_estimado_str = extracted_fields.get("monto_estimado_str")
+            if monto_estimado_str:
+                try:
+                    budget = float(str(monto_estimado_str).replace(",", ".")) # Handle potential commas
+                except (ValueError, TypeError):
+                    logger.warning(f"Could not parse monto_estimado_str for CABA: {monto_estimado_str}")
+            
+            # Use current time for fecha_scraping, as this is when the scraping occurs.
+            # If the source provides a "last updated" or "scraped by source" time, that would be a different field.
+            fecha_scraping = datetime.now()
+
+            # --- Field Validations & LicitacionCreate instantiation ---
+            # Required fields in LicitacionCreate are:
+            # From Base: title, organization, publication_date
+            # From Create: id_licitacion, jurisdiccion, tipo_procedimiento
+
+            # Using .get() with defaults for safety, even if some are marked "UNKNOWN"
+            licitacion_data = LicitacionCreate(
+                id_licitacion=str(extracted_fields.get("id_licitacion") or "CABA_ID_UNKNOWN"),
+                title=str(extracted_fields.get("titulo") or "CABA_TITLE_UNKNOWN"),
+                organization=str(extracted_fields.get("organismo") or "CABA_ORG_UNKNOWN"),
+                jurisdiccion=str(extracted_fields.get("jurisdiccion") or "CABA_JURISD_UNKNOWN"),
+                publication_date=publication_date or datetime.now(), # Default to now if parsing fails
+                licitacion_number=str(extracted_fields.get("numero_licitacion") or "CABA_NUM_LIC_UNKNOWN"),
+                description=str(extracted_fields.get("descripcion")) if extracted_fields.get("descripcion") else None,
+                status=str(extracted_fields.get("estado_licitacion") or "CABA_STATUS_UNKNOWN"),
+                budget=budget,
+                source_url=HttpUrl(source_url),
+                tipo_procedimiento=str(extracted_fields.get("tipo_procedimiento") or "CABA_TIPO_PROC_UNKNOWN"),
+                tipo_acceso=str(extracted_fields.get("tipo_acceso")) if extracted_fields.get("tipo_acceso") else None,
+                fecha_scraping=fecha_scraping,
+                # Other LicitacionBase fields (e.g., opening_date, expiration_date, etc.) would be mapped similarly if available
+            )
+            
+            # Check if critical information was actually found, even with defaults
+            if any(val.endswith("_UNKNOWN") for val in [licitacion_data.id_licitacion, licitacion_data.title, licitacion_data.organization, licitacion_data.jurisdiccion, licitacion_data.tipo_procedimiento]):
+                 logger.warning(f"Created CABA LicitacionCreate object with placeholder values due to missing critical data from source: {licitacion_data.id_licitacion}")
+            
+            logger.info(f"Successfully processed (placeholder) data for CABA id_licitacion: {licitacion_data.id_licitacion}")
+            return licitacion_data
+
+        except Exception as e:
+            logger.error(f"Error creating LicitacionCreate for CABA: {e}. Data received: {data}, Extracted fields: {extracted_fields}")
+            logger.error("Actual source structure (API or HTML) is needed to correctly implement field mapping for CabaScraper.")
+            return None
+
+    async def extract_links(self, data: Any) -> List[str]:
+        """
+        Extracts links to individual licitación details from an API list response or HTML page.
+        
+        Args:
+            data: The API response / HTML content.
+            
+        Returns:
+            A list of URLs for detail items.
+        """
+        logger.info("Attempting to extract links for CABA.")
+        logger.warning("Placeholder implementation for CabaScraper.extract_links. Source details (API/HTML) are needed.")
+        
+        links = []
+        if isinstance(data, dict): # Assuming API response
+            # items = data.get("results", []) or data.get("items", []) # Common keys for lists in APIs
+            # for item in items:
+            #     if isinstance(item, dict):
+            #         link = item.get("detail_url") or item.get("url")
+            #         if link: links.append(link)
+            pass
+        elif isinstance(data, str): # Assuming HTML content
+            # soup = BeautifulSoup(data, "html.parser")
+            # for a_tag in soup.find_all("a", href=True): # Example
+            #     link = a_tag["href"]
+            #     # Add logic to qualify/filter links (e.g., ensure they point to licitaciones)
+            #     # if "/licitacion-detail/" in link: links.append(self.construct_full_url(link))
+            pass
+        
+        if not links:
+            logger.info("No links extracted by CabaScraper. This might be normal or indicate an issue with source understanding.")
+        return links
+
+    async def get_next_page_url(self, data: Any, current_url: str) -> Optional[str]:
+        """
+        Determines the URL for the next page of results from an API response or HTML page.
+        
+        Args:
+            data: The current API response / HTML content.
+            current_url: The URL that yielded the current response.
+            
+        Returns:
+            The URL for the next page, or None if there is no next page.
+        """
+        logger.info(f"Attempting to determine next page URL for CABA from current_url: {current_url}")
+        logger.warning("Placeholder implementation for CabaScraper.get_next_page_url. Source (API/HTML) details are needed.")
+        
+        if isinstance(data, dict): # Assuming API response
+            # next_page_link = data.get("pagination", {}).get("next_page_url")
+            # if next_page_link: return next_page_link
+            pass
+        elif isinstance(data, str): # Assuming HTML content
+            # soup = BeautifulSoup(data, "html.parser")
+            # next_link_tag = soup.select_one("a.next_page_selector") # Example
+            # if next_link_tag and next_link_tag.get("href"):
+            #     return self.construct_full_url(next_link_tag["href"]) # Ensure it's a full URL
+            pass
+            
+        logger.info("No next page URL found or determined by CabaScraper (placeholder).")
+        return None
+
+    # def construct_full_url(self, path: str) -> str:
+    #     """ Helper to construct full URLs if the source provides relative paths. """
+    #     if path.startswith(("http://", "https://")):
+    #         return path
+    #     # Requires self.base_url to be set in __init__
+    #     if hasattr(self, 'base_url') and self.base_url:
+    #         from urllib.parse import urljoin
+    #         return urljoin(self.base_url, path)
+    #     logger.warning(f"Cannot construct full URL for path: {path} as base_url is not set.")
+    #     return path
+
+# Example usage (for testing purposes, would not be part of the final scraper file usually)
+# if __name__ == '__main__':
+#     # This part would require an async environment to run properly
+#     # import asyncio
+#     scraper = CabaScraper()
+    
+#     # Mock API data (replace with actual structure when known)
+#     mock_caba_api_item = {
+#         "id_licitacion_api": "CABA-LIC-2023-001",
+#         "titulo_api": "Servicio de Limpieza Edificios Gubernamentales",
+#         "organismo_api": "Secretaría General GCBA",
+#         "jurisdiccion_api": "Ciudad Autónoma de Buenos Aires",
+#         "fecha_publicacion_api": "2023-11-01T12:00:00Z",
+#         "numero_licitacion_api": "LIC-GCBA-SG-001-23",
+#         "descripcion_api": "Contratación de servicio de limpieza integral.",
+#         "estado_licitacion_api": "Publicada",
+#         "monto_estimado_api": "2500000.75",
+#         "tipo_procedimiento_api": "Licitación Pública Nacional",
+#         "tipo_acceso_api": "BAC Compras",
+#     }
+    
+#     async def main():
+#         licitacion = await scraper.extract_licitacion_data(mock_caba_api_item, "http://api.caba.example.com/licitaciones/CABA-LIC-2023-001")
+#         if licitacion:
+#             print("Extracted Licitacion (from mock API data):")
+#             print(licitacion.model_dump_json(indent=2))
+
+#         # Mock HTML content (very basic example)
+#         mock_html_content = """
+#         <html><body>
+#             <div id='id_element_selector'>CABA-HTML-002</div>
+#             <h1 class='title_selector'>Mantenimiento Espacios Verdes</h1>
+#             <span>Organismo: Ministerio Ambiente y Espacio Público</span>
+#             <a href='/licitaciones/detalle/002'>Detalle</a>
+#             <a class='next_page_selector' href='?page=2'>Siguiente</a>
+#         </body></html>
+#         """
+#         # Note: The current placeholder for HTML in extract_licitacion_data doesn't actually parse.
+#         # This call would result in UNKNOWN fields if it were to create an object from HTML.
+#         licitacion_html = await scraper.extract_licitacion_data(mock_html_content, "http://www.caba.example.com/licitaciones/page1")
+#         if licitacion_html:
+#             print("\nExtracted Licitacion (from mock HTML data - placeholder):")
+#             print(licitacion_html.model_dump_json(indent=2))
+        
+#         links = await scraper.extract_links(mock_html_content) # Placeholder, will be empty
+#         print(f"\nExtracted links (from HTML - placeholder): {links}")
+        
+#         next_page = await scraper.get_next_page_url(mock_html_content, "http://www.caba.example.com/licitaciones/page1") # Placeholder
+#         print(f"\nNext page URL (from HTML - placeholder): {next_page}")
+
+#     # asyncio.run(main())
+```

--- a/backend/scrapers/cordoba_provincia_scraper.py
+++ b/backend/scrapers/cordoba_provincia_scraper.py
@@ -1,0 +1,265 @@
+from typing import Optional, List, Any
+from datetime import datetime
+import logging
+from urllib.parse import urljoin
+
+from pydantic import HttpUrl
+from bs4 import BeautifulSoup
+
+from backend.models.licitacion import LicitacionCreate
+from backend.scrapers.base_scraper import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+# Helper function to safely get text or None from a BeautifulSoup element
+def get_text_or_none(element: Optional[Any]) -> Optional[str]:
+    if element:
+        return element.get_text(strip=True)
+    return None
+
+class CordobaProvinciaScraper(BaseScraper):
+    """
+    Scraper for the 'Córdoba Provincia' data source.
+    This scraper is designed for web scraping HTML content.
+    """
+
+    def __init__(self):
+        super().__init__(source_name="Córdoba Provincia")
+        # TODO: Set the actual base URL for the Cordoba Provincia portal if known
+        # self.base_url = "https://compraspublicas.cba.gov.ar/" # Example
+        self.base_url = "https://placeholder.cordoba.gov.ar" # Placeholder to allow urljoin to work
+
+    async def extract_licitacion_data(self, html_content: str, source_url: str) -> Optional[LicitacionCreate]:
+        """
+        Extracts licitación data from HTML content of a detail page.
+        
+        Args:
+            html_content: The HTML content of the licitación detail page.
+            source_url: The URL from which this HTML was fetched.
+            
+        Returns:
+            A LicitacionCreate object or None if data extraction fails.
+        """
+        logger.info(f"Attempting to extract data for Cordoba Provincia from source_url: {source_url}")
+        soup = BeautifulSoup(html_content, "html.parser")
+        
+        # Placeholder selectors - these need to be replaced with actual selectors from the website
+        logger.warning("Using placeholder selectors for CordobaProvinciaScraper.extract_licitacion_data. These must be updated.")
+
+        extracted_fields = {
+            "id_licitacion": get_text_or_none(soup.select_one("div.licitacion-id > span.valor")), # Example selector
+            "titulo": get_text_or_none(soup.select_one("h1.licitacion-titulo")),
+            "organismo": get_text_or_none(soup.select_one("div.info-organismo > p")),
+            "jurisdiccion": "Córdoba Provincia", # Often fixed for a provincial scraper
+            "fecha_publicacion_str": get_text_or_none(soup.select_one("span.fecha-publicacion")),
+            "numero_licitacion": get_text_or_none(soup.select_one("div.numero-expediente > span.valor")),
+            "descripcion": get_text_or_none(soup.select_one("div.descripcion-licitacion")),
+            "estado_licitacion": get_text_or_none(soup.select_one("span.estado-actual")),
+            "monto_estimado_str": get_text_or_none(soup.select_one("div.monto-estimado > span.valor")),
+            "tipo_procedimiento": get_text_or_none(soup.select_one("div.tipo-procedimiento > span.valor")),
+            "municipios_cubiertos": get_text_or_none(soup.select_one("div.municipios > span.valor")), # May not exist or be structured
+        }
+
+        try:
+            publication_date = None
+            if extracted_fields["fecha_publicacion_str"]:
+                try:
+                    # TODO: Adjust datetime parsing based on actual date format on the website
+                    # Example: datetime.strptime(extracted_fields["fecha_publicacion_str"], "%d/%m/%Y")
+                    publication_date = datetime.fromisoformat(extracted_fields["fecha_publicacion_str"].replace(" ", "T")) # Basic ISO
+                except ValueError:
+                    logger.warning(f"Could not parse fecha_publicacion_str for Cordoba: {extracted_fields['fecha_publicacion_str']}")
+
+            budget = None
+            if extracted_fields["monto_estimado_str"]:
+                try:
+                    # Clean string: remove currency symbols, thousand separators, use . for decimal
+                    cleaned_monto = extracted_fields["monto_estimado_str"].replace("$", "").replace(".", "").replace(",", ".").strip()
+                    budget = float(cleaned_monto)
+                except (ValueError, TypeError):
+                    logger.warning(f"Could not parse monto_estimado_str for Cordoba: {extracted_fields['monto_estimado_str']}")
+
+            fecha_scraping = datetime.now()
+            tipo_acceso = "Web scraping" # As specified
+
+            # Use .get() with defaults for safety, even if some are marked "UNKNOWN"
+            licitacion_data = LicitacionCreate(
+                id_licitacion=str(extracted_fields.get("id_licitacion") or f"CORDOBA_ID_UNKNOWN_{source_url}"),
+                title=str(extracted_fields.get("titulo") or "CORDOBA_TITLE_UNKNOWN"),
+                organization=str(extracted_fields.get("organismo") or "CORDOBA_ORG_UNKNOWN"),
+                jurisdiccion=str(extracted_fields.get("jurisdiccion") or "Córdoba Provincia"),
+                publication_date=publication_date or datetime.now(), # Default to now if parsing fails
+                licitacion_number=str(extracted_fields.get("numero_licitacion") or "CORDOBA_NUM_LIC_UNKNOWN"),
+                description=extracted_fields.get("descripcion"),
+                status=str(extracted_fields.get("estado_licitacion") or "CORDOBA_STATUS_UNKNOWN"),
+                budget=budget,
+                source_url=HttpUrl(source_url),
+                tipo_procedimiento=str(extracted_fields.get("tipo_procedimiento") or "CORDOBA_TIPO_PROC_UNKNOWN"),
+                tipo_acceso=tipo_acceso,
+                municipios_cubiertos=extracted_fields.get("municipios_cubiertos"),
+                fecha_scraping=fecha_scraping,
+            )
+            
+            if any(val is None or "_UNKNOWN" in str(val) for key, val in licitacion_data.model_dump().items() if key in ["id_licitacion", "title", "organization", "publication_date", "licitacion_number", "status", "tipo_procedimiento"]):
+                 logger.warning(f"Created Cordoba LicitacionCreate object with some missing or placeholder critical data from source: {licitacion_data.id_licitacion}")
+
+            logger.info(f"Successfully processed (placeholder selectors) data for Cordoba id_licitacion: {licitacion_data.id_licitacion}")
+            return licitacion_data
+
+        except Exception as e:
+            logger.error(f"Error creating LicitacionCreate for Cordoba: {e}. HTML source: {source_url}, Extracted fields: {extracted_fields}")
+            logger.error("Actual HTML structure and selectors are needed for CordobaProvinciaScraper.")
+            return None
+
+    async def extract_links(self, html_content: str) -> List[str]:
+        """
+        Extracts links to individual licitación detail pages from a listing page HTML.
+        
+        Args:
+            html_content: The HTML content of the listing page.
+            
+        Returns:
+            A list of URLs for detail items.
+        """
+        logger.info("Attempting to extract links for Cordoba Provincia.")
+        soup = BeautifulSoup(html_content, "html.parser")
+        
+        # Placeholder selector - needs to be replaced with actual selector for licitacion links
+        logger.warning("Using placeholder selectors for CordobaProvinciaScraper.extract_links. These must be updated.")
+        
+        links = []
+        # Example: link_elements = soup.select("div.licitacion-item > a.detalle-link")
+        link_elements = soup.select("a.placeholder-licitacion-link-selector") 
+
+        for element in link_elements:
+            href = element.get("href")
+            if href:
+                full_url = urljoin(self.base_url, href) # Construct absolute URL
+                links.append(full_url)
+        
+        if not links:
+            logger.info("No links extracted by CordobaProvinciaScraper. Check selectors or if page structure changed.")
+        else:
+            logger.info(f"Extracted {len(links)} links using placeholder selectors from Cordoba Provincia.")
+        return links
+
+    async def get_next_page_url(self, html_content: str, current_url: str) -> Optional[str]:
+        """
+        Determines the URL for the next page of results from listing page HTML.
+        
+        Args:
+            html_content: The HTML content of the current listing page.
+            current_url: The URL that yielded the current response (unused in this placeholder, but good practice).
+            
+        Returns:
+            The URL for the next page, or None if there is no next page.
+        """
+        logger.info(f"Attempting to determine next page URL for Cordoba Provincia from current_url: {current_url}")
+        soup = BeautifulSoup(html_content, "html.parser")
+        
+        # Placeholder selector - needs to be replaced with actual selector for the "next page" link
+        logger.warning("Using placeholder selectors for CordobaProvinciaScraper.get_next_page_url. These must be updated.")
+        
+        # Example: next_page_element = soup.select_one("a.pagination-next")
+        next_page_element = soup.select_one("a.placeholder-next-page-selector") 
+        
+        if next_page_element:
+            href = next_page_element.get("href")
+            if href:
+                full_url = urljoin(self.base_url, href) # Construct absolute URL
+                logger.info(f"Found next page URL (placeholder selector): {full_url}")
+                return full_url
+            
+        logger.info("No next page URL found by CordobaProvinciaScraper (placeholder selector).")
+        return None
+
+# Example usage (for testing purposes, would not be part of the final scraper file usually)
+# if __name__ == '__main__':
+#     # This part would require an async environment to run properly
+#     # import asyncio
+#     scraper = CordobaProvinciaScraper()
+#     scraper.base_url = "https://compraspublicas.cba.gov.ar/" # Example, replace if different
+
+#     # Mock HTML for a detail page (replace with actual structure sample)
+#     mock_detail_html = """
+#     <html><body>
+#         <h1 class='licitacion-titulo'>Adquisición de Equipamiento Informático</h1>
+#         <div class='licitacion-id'><label>ID:</label><span class='valor'>LIC-2023-001-CBA</span></div>
+#         <div class='info-organismo'><p>Ministerio de Finanzas de Córdoba</p></div>
+#         <span class='fecha-publicacion'>2023-11-15</span>
+#         <div class='numero-expediente'><label>Expediente:</label><span class='valor'>EXP-2023-XYZ</span></div>
+#         <div class='descripcion-licitacion'>Detalle de la adquisición de PCs y notebooks.</div>
+#         <span class='estado-actual'>Abierta</span>
+#         <div class='monto-estimado'><label>Monto:</label><span class='valor'>$ 1.250.000,50</span></div>
+#         <div class='tipo-procedimiento'><label>Tipo:</label><span class='valor'>Licitación Pública</span></div>
+#         <div class='municipios'><label>Cobertura:</label><span class='valor'>Provincial</span></div>
+#     </body></html>
+#     """
+    
+#     # Mock HTML for a listing page (replace with actual structure sample)
+#     mock_listing_html = """
+#     <html><body>
+#         <a class="placeholder-licitacion-link-selector" href="/detalle/licitacion1">Licitacion 1</a>
+#         <a class="placeholder-licitacion-link-selector" href="/otra/ruta/licitacion2.html">Licitacion 2</a>
+#         <a class="placeholder-next-page-selector" href="?page=2">Siguiente</a>
+#     </body></html>
+#     """
+
+#     async def main():
+#         print("--- Testing extract_licitacion_data ---")
+#         # Forcing selectors to match mock HTML for this test
+#         # In reality, these would be the actual complex selectors.
+#         _get_text_or_none_orig = get_text_or_none
+#         def mock_get_text_or_none(element): return _get_text_or_none_orig(element) if element else "MOCK_TEXT" # ensure it returns something for demo
+
+#         # Temporarily adjust selectors for the mock HTML
+#         original_extract = scraper.extract_licitacion_data
+#         async def temp_extract_data(html_content, source_url):
+#             soup = BeautifulSoup(html_content, "html.parser")
+#             extracted_fields = {
+#                 "id_licitacion": get_text_or_none(soup.select_one("div.licitacion-id > span.valor")),
+#                 "titulo": get_text_or_none(soup.select_one("h1.licitacion-titulo")),
+#                 "organismo": get_text_or_none(soup.select_one("div.info-organismo > p")),
+#                 "jurisdiccion": "Córdoba Provincia",
+#                 "fecha_publicacion_str": get_text_or_none(soup.select_one("span.fecha-publicacion")),
+#                 "numero_licitacion": get_text_or_none(soup.select_one("div.numero-expediente > span.valor")),
+#                 "descripcion": get_text_or_none(soup.select_one("div.descripcion-licitacion")),
+#                 "estado_licitacion": get_text_or_none(soup.select_one("span.estado-actual")),
+#                 "monto_estimado_str": get_text_or_none(soup.select_one("div.monto-estimado > span.valor")),
+#                 "tipo_procedimiento": get_text_or_none(soup.select_one("div.tipo-procedimiento > span.valor")),
+#                 "municipios_cubiertos": get_text_or_none(soup.select_one("div.municipios > span.valor")),
+#             }
+#             # Re-apply the conversion and LicitacionCreate logic from the original method
+#             # This part is simplified for brevity in this test setup.
+#             # The goal is to show the placeholder selectors would be used.
+#             print(f"Mock extracted fields: {extracted_fields}") # Show what selectors found
+            
+#             # Call the original method logic but with our controlled soup/extracted_fields if needed
+#             # For this test, we will assume the placeholder selectors in the main method are updated.
+#             # This is just to simulate that the main method would use its defined (placeholder) selectors.
+#             return await original_extract(html_content, source_url)
+
+
+#         # licitacion = await temp_extract_data(mock_detail_html, f"{scraper.base_url}/detalle/licitacion_ejemplo1")
+#         # The above test setup for extract_licitacion_data is tricky because the selectors are hardcoded.
+#         # For a real test, you'd pass HTML that matches the *actual* placeholder selectors in the method,
+#         # or update the selectors in the method to match your mock_detail_html.
+#         # The current placeholder selectors will likely not find anything in mock_detail_html.
+#         # We'll call it directly to see the warnings.
+#         licitacion = await scraper.extract_licitacion_data(mock_detail_html, f"{scraper.base_url}/detalle/licitacion_ejemplo1")
+#         if licitacion:
+#             print("\nExtracted Licitacion (from mock HTML - using placeholder selectors):")
+#             print(licitacion.model_dump_json(indent=2))
+#         else:
+#             print("\nLicitacion extraction failed as expected with placeholder selectors.")
+
+#         print("\n--- Testing extract_links ---")
+#         links = await scraper.extract_links(mock_listing_html)
+#         print(f"Extracted links (using placeholder selectors): {links}")
+        
+#         print("\n--- Testing get_next_page_url ---")
+#         next_page = await scraper.get_next_page_url(mock_listing_html, f"{scraper.base_url}/licitaciones?page=1")
+#         print(f"Next page URL (using placeholder selectors): {next_page}")
+
+#     # asyncio.run(main())
+```

--- a/backend/scrapers/mendoza_provincia_scraper.py
+++ b/backend/scrapers/mendoza_provincia_scraper.py
@@ -1,0 +1,277 @@
+from typing import Optional, List, Any
+from datetime import datetime
+import logging
+
+from pydantic import HttpUrl
+
+from backend.models.licitacion import LicitacionCreate
+from backend.scrapers.base_scraper import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+# Helper to navigate OCDS-like structures safely
+def get_ocds_value(data: dict, path: str, default: Any = None) -> Any:
+    keys = path.split('.')
+    current = data
+    for key in keys:
+        if isinstance(current, dict) and key in current:
+            current = current[key]
+        elif isinstance(current, list) and key.isdigit() and int(key) < len(current):
+            current = current[int(key)]
+        else:
+            return default
+    return current
+
+class MendozaProvinciaScraper(BaseScraper):
+    """
+    Scraper for the 'Mendoza Provincia' data source.
+    Prioritizes OCDS data if available via API.
+    """
+
+    def __init__(self):
+        super().__init__(source_name="Mendoza Provincia")
+        # TODO: Initialize with the actual OCDS API base URL or relevant endpoint
+        # self.base_api_url = "https://datos.mendoza.gov.ar/api/ocds/" # Example
+        self.base_api_url = "https://placeholder.mendoza.api/ocds" # Placeholder
+
+    async def extract_licitacion_data(self, api_data: Any, source_url: str) -> Optional[LicitacionCreate]:
+        """
+        Extracts licitación data from an API response item, ideally an OCDS release or record.
+        
+        Args:
+            api_data: A dictionary, ideally an OCDS release or a tender object.
+            source_url: The URL from which this data item was effectively sourced.
+            
+        Returns:
+            A LicitacionCreate object or None if data extraction fails.
+        """
+        logger.info(f"Attempting to extract data for Mendoza Provincia (OCDS prioritized) from: {source_url}")
+
+        if not isinstance(api_data, dict):
+            logger.error(f"Input api_data for Mendoza is not a dictionary. Cannot extract details. Data: {api_data}")
+            logger.warning("Actual API response structure (OCDS or other) is needed for MendozaProvinciaScraper.")
+            return None
+
+        logger.warning("Using placeholder OCDS paths / API field names for MendozaProvinciaScraper.extract_licitacion_data. These must be verified and updated.")
+
+        # Assuming api_data could be an OCDS release. A release contains a 'tender' object.
+        # If it's a list of tenders directly, adjust accordingly.
+        # For a full release package, this method would be called for each release in the package.
+        
+        tender_data = get_ocds_value(api_data, "tender", {}) # If 'tender' is not at root, this will be empty
+        if not tender_data and api_data: # Maybe api_data is the tender object itself or a non-OCDS structure
+            logger.info("No 'tender' field found at root of api_data. Assuming api_data itself is the tender object or a custom structure.")
+            tender_data = api_data # Try to use api_data directly
+
+        extracted_fields = {
+            "id_licitacion": get_ocds_value(api_data, "ocid") or get_ocds_value(tender_data, "id"), # OCID or tender.id
+            "titulo": get_ocds_value(tender_data, "title"),
+            "organismo": get_ocds_value(api_data, "buyer.name") or get_ocds_value(tender_data, "buyers.0.name") or get_ocds_value(tender_data, "procuringEntity.name"), # More flexible buyer lookup
+            "jurisdiccion": "Mendoza Provincia", # Typically fixed
+            "fecha_publicacion_str": get_ocds_value(tender_data, "datePublished") or get_ocds_value(tender_data, "tenderPeriod.startDate"),
+            "numero_licitacion": get_ocds_value(tender_data, "id"), # tender.id often serves as this
+            "descripcion": get_ocds_value(tender_data, "description"),
+            "estado_licitacion": get_ocds_value(tender_data, "status"),
+            "monto_estimado_str": get_ocds_value(tender_data, "value.amount"),
+            "moneda": get_ocds_value(tender_data, "value.currency"),
+            "tipo_procedimiento": get_ocds_value(tender_data, "procurementMethodDetails") or get_ocds_value(tender_data, "procurementMethod"),
+            "municipios_cubiertos": None, # OCDS doesn't have a standard field, might be in tender.items.deliveryAddress.locality or custom extensions
+        }
+        
+        # If still no id_licitacion, try a generic id from api_data root
+        if not extracted_fields["id_licitacion"]:
+            extracted_fields["id_licitacion"] = api_data.get("id_api_generic")
+
+
+        try:
+            publication_date = None
+            if extracted_fields["fecha_publicacion_str"]:
+                try:
+                    publication_date = datetime.fromisoformat(str(extracted_fields["fecha_publicacion_str"]).replace("Z", "+00:00"))
+                except (ValueError, TypeError):
+                    logger.warning(f"Could not parse fecha_publicacion_str for Mendoza: {extracted_fields['fecha_publicacion_str']}")
+
+            budget = None
+            if extracted_fields["monto_estimado_str"] is not None: # OCDS amount can be 0
+                try:
+                    budget = float(extracted_fields["monto_estimado_str"])
+                except (ValueError, TypeError):
+                    logger.warning(f"Could not parse monto_estimado_str for Mendoza: {extracted_fields['monto_estimado_str']}")
+            
+            fecha_scraping = datetime.now()
+            tipo_acceso = "API/OCDS" # As specified
+
+            licitacion_data = LicitacionCreate(
+                id_licitacion=str(extracted_fields.get("id_licitacion") or f"MENDOZA_ID_UNKNOWN_{source_url}"),
+                title=str(extracted_fields.get("titulo") or "MENDOZA_TITLE_UNKNOWN"),
+                organization=str(extracted_fields.get("organismo") or "MENDOZA_ORG_UNKNOWN"),
+                jurisdiccion=str(extracted_fields.get("jurisdiccion") or "Mendoza Provincia"),
+                publication_date=publication_date or datetime.now(),
+                licitacion_number=str(extracted_fields.get("numero_licitacion") or "MENDOZA_NUM_LIC_UNKNOWN"),
+                description=extracted_fields.get("descripcion"),
+                status=str(extracted_fields.get("estado_licitacion") or "MENDOZA_STATUS_UNKNOWN"),
+                budget=budget,
+                currency=extracted_fields.get("moneda"),
+                source_url=HttpUrl(source_url),
+                tipo_procedimiento=str(extracted_fields.get("tipo_procedimiento") or "MENDOZA_TIPO_PROC_UNKNOWN"),
+                tipo_acceso=tipo_acceso,
+                municipios_cubiertos=extracted_fields.get("municipios_cubiertos"),
+                fecha_scraping=fecha_scraping,
+            )
+            
+            if any(val is None or "_UNKNOWN" in str(val) for key, val in licitacion_data.model_dump().items() if key in ["id_licitacion", "title", "organization", "publication_date", "licitacion_number", "status", "tipo_procedimiento"]):
+                 logger.warning(f"Created Mendoza LicitacionCreate object with some missing or placeholder critical data from source: {licitacion_data.id_licitacion}")
+
+            logger.info(f"Successfully processed (placeholder OCDS/API fields) data for Mendoza id_licitacion: {licitacion_data.id_licitacion}")
+            return licitacion_data
+
+        except Exception as e:
+            logger.error(f"Error creating LicitacionCreate for Mendoza: {e}. API data: {api_data}, Extracted fields: {extracted_fields}")
+            logger.error("Actual API/OCDS response structure is needed for MendozaProvinciaScraper.")
+            return None
+
+    async def extract_links(self, api_response: Any) -> List[str]:
+        """
+        Extracts links or identifiers (e.g., OCIDs) from an API response, possibly an OCDS Release Package.
+        
+        Args:
+            api_response: The full API response. For OCDS, this might be a Release Package.
+            
+        Returns:
+            A list of OCIDs or URLs that can be used to fetch/identify individual licitación data.
+        """
+        logger.info("Attempting to extract links/OCIDs for Mendoza Provincia.")
+        logger.warning("Placeholder implementation for MendozaProvinciaScraper.extract_links. OCDS/API details are needed.")
+        
+        links_or_ids = []
+        if isinstance(api_response, dict):
+            # OCDS Release Package typically has a 'releases' array
+            releases = get_ocds_value(api_response, "releases", [])
+            if isinstance(releases, list):
+                for release in releases:
+                    if isinstance(release, dict):
+                        ocid = get_ocds_value(release, "ocid")
+                        if ocid:
+                            links_or_ids.append(ocid) # The OCID itself can be the identifier
+                        # Alternatively, a release might have a specific URL for itself or the tender
+                        # tender_url = get_ocds_value(release, "tender.url_detalle_portal") # Custom extension example
+                        # if tender_url: links_or_ids.append(tender_url)
+                logger.info(f"Extracted {len(links_or_ids)} OCIDs from 'releases' array (OCDS placeholder).")
+            else: # Non-OCDS structure or items directly under other keys
+                items_list = []
+                possible_keys = ["items", "data", "records", "licitaciones"]
+                for key in possible_keys:
+                    if key in api_response and isinstance(api_response[key], list):
+                        items_list = api_response[key]
+                        break
+                for item in items_list:
+                    if isinstance(item, dict):
+                        # item_id = item.get("id_api") or item.get("url_api") # Placeholder
+                        # if item_id: links_or_ids.append(item_id)
+                        pass # Add logic for non-OCDS list items
+                logger.info(f"Extracted {len(links_or_ids)} items from a generic list structure (placeholder).")
+
+        elif isinstance(api_response, list): # API returns a direct list of items/releases
+            for item in api_response:
+                if isinstance(item, dict):
+                    ocid = get_ocds_value(item, "ocid") # If it's a list of releases
+                    if ocid: links_or_ids.append(ocid)
+            logger.info(f"Extracted {len(links_or_ids)} OCIDs from a direct list of releases (OCDS placeholder).")
+        
+        if not links_or_ids:
+            logger.info("No links/OCIDs extracted by MendozaProvinciaScraper. Check API response structure (OCDS package, list of releases, or custom format).")
+        return links_or_ids
+
+    async def get_next_page_url(self, api_response: Any, current_url: str) -> Optional[str]:
+        """
+        Determines the URL for the next page of results from an API response (e.g., OCDS Release Package).
+        
+        Args:
+            api_response: The current API response.
+            current_url: The URL that yielded the current response.
+            
+        Returns:
+            The URL for the next page, or None if there is no next page.
+        """
+        logger.info(f"Attempting to determine next page URL for Mendoza from current_url: {current_url}")
+        logger.warning("Placeholder implementation for MendozaProvinciaScraper.get_next_page_url. OCDS/API pagination details are needed.")
+        
+        if not isinstance(api_response, dict):
+            logger.warning("Cannot determine next page: API response is not a dictionary for Mendoza.")
+            return None
+
+        # OCDS Release Packages can have a 'links.next' field for pagination
+        next_page_url = get_ocds_value(api_response, "links.next")
+        if next_page_url and isinstance(next_page_url, str):
+            logger.info(f"Found next page URL in OCDS links.next: {next_page_url}")
+            # Ensure it's a full URL. OCDS links should be absolute.
+            return next_page_url
+        
+        # Fallback to common non-OCDS pagination patterns
+        pagination_info = api_response.get("pagination", api_response.get("paging", {}))
+        if isinstance(pagination_info, dict):
+            next_page_url = pagination_info.get("next_page_url_api") or pagination_info.get("nextLink")
+            if next_page_url and isinstance(next_page_url, str):
+                logger.info(f"Found next page URL in generic pagination object: {next_page_url}")
+                # from urllib.parse import urljoin
+                # if not next_page_url.startswith(('http://', 'https://')):
+                #     next_page_url = urljoin(self.base_api_url or current_url, next_page_url)
+                return next_page_url
+        
+        logger.info("No next page URL found or determined by MendozaProvinciaScraper (placeholder).")
+        return None
+
+# Example usage (for testing purposes, would not be part of the final scraper file usually)
+# if __name__ == '__main__':
+#     # import asyncio
+#     scraper = MendozaProvinciaScraper()
+    
+#     # Mock OCDS-like tender data (simplified)
+#     mock_ocds_tender_item = {
+#         "ocid": "ocds-xyz-001",
+#         "id": "tender-001", # This is tender.id
+#         "buyer": {"name": "Ministerio de Hacienda Mendoza"},
+#         "tender": {
+#             "id": "tender-001", # Redundant here, but common in full releases
+#             "title": "Servicio de Consultoría Especializada",
+#             "description": "Consultoría para proyecto de modernización.",
+#             "status": "active",
+#             "value": {"amount": 75000.00, "currency": "ARS"},
+#             "datePublished": "2023-12-01T14:30:00Z",
+#             "procurementMethodDetails": "Licitación Privada",
+#         }
+#     }
+    
+#     # Mock OCDS Release Package (simplified)
+#     mock_ocds_release_package = {
+#         "uri": "https://ocds.example.com/api/releases.json?page=1",
+#         "publishedDate": "2023-12-05T10:00:00Z",
+#         "releases": [
+#             mock_ocds_tender_item, # In reality, a release contains more than just tender
+#             {**mock_ocds_tender_item, "ocid": "ocds-xyz-002", "tender": {**mock_ocds_tender_item["tender"], "title": "Otra Consultoria"}}
+#         ],
+#         "links": {
+#             "next": "https://ocds.example.com/api/releases.json?page=2"
+#         }
+#     }
+
+#     async def main():
+#         print("--- Testing extract_licitacion_data (OCDS-like) ---")
+#         # Assuming extract_licitacion_data is called with a single release object
+#         licitacion = await scraper.extract_licitacion_data(mock_ocds_tender_item, "https://ocds.example.com/release/ocds-xyz-001.json")
+#         if licitacion:
+#             print("Extracted Licitacion (from mock OCDS item - using placeholder fields):")
+#             print(licitacion.model_dump_json(indent=2))
+#         else:
+#             print("Licitacion extraction failed from mock OCDS item.")
+
+#         print("\n--- Testing extract_links (OCDS Release Package) ---")
+#         links_or_ocids = await scraper.extract_links(mock_ocds_release_package)
+#         print(f"Extracted links/OCIDs (from mock OCDS package - placeholder): {links_or_ocids}")
+        
+#         print("\n--- Testing get_next_page_url (OCDS Release Package) ---")
+#         next_page = await scraper.get_next_page_url(mock_ocds_release_package, mock_ocds_release_package["uri"])
+#         print(f"Next page URL (from mock OCDS package - placeholder): {next_page}")
+
+#     # asyncio.run(main())
+```

--- a/backend/scrapers/santa_fe_provincia_scraper.py
+++ b/backend/scrapers/santa_fe_provincia_scraper.py
@@ -1,0 +1,273 @@
+from typing import Optional, List, Any
+from datetime import datetime
+import logging
+
+from pydantic import HttpUrl
+
+from backend.models.licitacion import LicitacionCreate
+from backend.scrapers.base_scraper import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+class SantaFeProvinciaScraper(BaseScraper):
+    """
+    Scraper for the 'Santa Fe Provincia' data source.
+    This scraper is designed to fetch data from the provincial API.
+    """
+
+    def __init__(self):
+        super().__init__(source_name="Santa Fe Provincia")
+        # TODO: Initialize with the actual base API URL if known
+        # self.base_api_url = "https://api.santafe.gob.ar/licitaciones/" # Example
+        self.base_api_url = "https://placeholder.santafe.api" # Placeholder
+
+    async def extract_licitacion_data(self, api_data: Any, source_url: str) -> Optional[LicitacionCreate]:
+        """
+        Extracts licitación data from a single item of an API response.
+        
+        Args:
+            api_data: A dictionary representing a single licitación item from the API.
+            source_url: The URL from which this data item was effectively sourced (could be a detail URL or the list API URL).
+            
+        Returns:
+            A LicitacionCreate object or None if data extraction fails.
+        """
+        logger.info(f"Attempting to extract data for Santa Fe Provincia from source_url: {source_url}")
+        
+        if not isinstance(api_data, dict):
+            logger.error(f"Input api_data for Santa Fe is not a dictionary. Cannot extract details. Data: {api_data}")
+            logger.warning("Actual API response structure (for individual items) is needed for SantaFeProvinciaScraper.")
+            return None
+
+        logger.warning("Using placeholder API field names for SantaFeProvinciaScraper.extract_licitacion_data. These must be updated based on the actual API.")
+
+        # Placeholder: Assume direct mapping for some fields using _api suffix.
+        extracted_fields = {
+            "id_licitacion": api_data.get("id_api"), 
+            "titulo": api_data.get("titulo_api"), 
+            "organismo": api_data.get("organismo_api"),
+            "jurisdiccion": "Santa Fe Provincia", # Often fixed for a provincial scraper
+            "fecha_publicacion_str": api_data.get("fecha_publicacion_api"),
+            "numero_licitacion": api_data.get("numero_expediente_api"),
+            "descripcion": api_data.get("objeto_licitacion_api"),
+            "estado_licitacion": api_data.get("estado_api"),
+            "monto_estimado_str": api_data.get("monto_oficial_api"),
+            "tipo_procedimiento": api_data.get("tipo_contratacion_api"),
+            "municipios_cubiertos": api_data.get("lugar_entrega_api"), # This is an assumption, might need specific mapping
+        }
+
+        try:
+            publication_date = None
+            if extracted_fields["fecha_publicacion_str"]:
+                try:
+                    # TODO: Adjust datetime parsing based on actual date format from API
+                    publication_date = datetime.fromisoformat(str(extracted_fields["fecha_publicacion_str"]).replace("Z", "+00:00"))
+                except (ValueError, TypeError):
+                    logger.warning(f"Could not parse fecha_publicacion_str for Santa Fe: {extracted_fields['fecha_publicacion_str']}")
+
+            budget = None
+            if extracted_fields["monto_estimado_str"]:
+                try:
+                    cleaned_monto = str(extracted_fields["monto_estimado_str"]).replace("$", "").replace(".", "").replace(",", ".").strip()
+                    budget = float(cleaned_monto)
+                except (ValueError, TypeError):
+                    logger.warning(f"Could not parse monto_estimado_str for Santa Fe: {extracted_fields['monto_estimado_str']}")
+
+            fecha_scraping = datetime.now()
+            tipo_acceso = "API provincial" # As specified
+
+            licitacion_data = LicitacionCreate(
+                id_licitacion=str(extracted_fields.get("id_licitacion") or f"SANTAFE_ID_UNKNOWN_{source_url}"),
+                title=str(extracted_fields.get("titulo") or "SANTAFE_TITLE_UNKNOWN"),
+                organization=str(extracted_fields.get("organismo") or "SANTAFE_ORG_UNKNOWN"),
+                jurisdiccion=str(extracted_fields.get("jurisdiccion") or "Santa Fe Provincia"), # Fallback
+                publication_date=publication_date or datetime.now(), # Default if parsing fails
+                licitacion_number=str(extracted_fields.get("numero_licitacion") or "SANTAFE_NUM_LIC_UNKNOWN"),
+                description=extracted_fields.get("descripcion"),
+                status=str(extracted_fields.get("estado_licitacion") or "SANTAFE_STATUS_UNKNOWN"),
+                budget=budget,
+                source_url=HttpUrl(source_url), # Use the provided source_url
+                tipo_procedimiento=str(extracted_fields.get("tipo_procedimiento") or "SANTAFE_TIPO_PROC_UNKNOWN"),
+                tipo_acceso=tipo_acceso,
+                municipios_cubiertos=extracted_fields.get("municipios_cubiertos"),
+                fecha_scraping=fecha_scraping,
+                # Other LicitacionBase fields (e.g., opening_date, expiration_date, etc.) would be mapped similarly if available
+            )
+            
+            if any(val is None or "_UNKNOWN" in str(val) for key, val in licitacion_data.model_dump().items() if key in ["id_licitacion", "title", "organization", "publication_date", "licitacion_number", "status", "tipo_procedimiento"]):
+                 logger.warning(f"Created Santa Fe LicitacionCreate object with some missing or placeholder critical data from source: {licitacion_data.id_licitacion}")
+
+            logger.info(f"Successfully processed (placeholder API fields) data for Santa Fe id_licitacion: {licitacion_data.id_licitacion}")
+            return licitacion_data
+
+        except Exception as e:
+            logger.error(f"Error creating LicitacionCreate for Santa Fe: {e}. API data item: {api_data}, Extracted fields: {extracted_fields}")
+            logger.error("Actual API response structure is needed to correctly implement field mapping for SantaFeProvinciaScraper.")
+            return None
+
+    async def extract_links(self, api_response: Any) -> List[str]:
+        """
+        Extracts links or identifiers for individual licitaciones from an API list response.
+        
+        Args:
+            api_response: The full API response, expected to contain a list of licitación items or items with detail URLs.
+            
+        Returns:
+            A list of URLs or unique identifiers for detail items.
+        """
+        logger.info("Attempting to extract links for Santa Fe Provincia.")
+        logger.warning("Placeholder implementation for SantaFeProvinciaScraper.extract_links. API details are needed.")
+        
+        links = []
+        items_list = []
+
+        if isinstance(api_response, list): # API returns a direct list of items
+            items_list = api_response
+        elif isinstance(api_response, dict): # API returns a dict with items under a key
+            # Common keys: "items", "data", "results", "licitaciones"
+            possible_keys = ["items", "data", "results", "licitaciones", "records"]
+            for key in possible_keys:
+                if key in api_response and isinstance(api_response[key], list):
+                    items_list = api_response[key]
+                    logger.info(f"Found items list under key '{key}' in API response.")
+                    break
+            if not items_list:
+                 logger.warning(f"API response is a dict, but no list found under common keys: {possible_keys}")
+        else:
+            logger.error(f"API response format for Santa Fe not recognized (expected list or dict). Got: {type(api_response)}")
+            return links
+
+        for item in items_list:
+            if isinstance(item, dict):
+                # Option 1: Item has a direct URL to its details
+                detail_url = item.get("url_detalle_api") # Placeholder key
+                if detail_url and isinstance(detail_url, str):
+                    links.append(detail_url)
+                # Option 2: Item has an ID that can be used to construct a detail URL or is the identifier itself
+                # item_id = item.get("id_api") # Placeholder key
+                # if item_id:
+                #     # If the "link" is just the ID to be processed later by extract_licitacion_data with the item itself
+                #     # links.append(str(item_id)) 
+                #     # Or construct a URL if there's a known pattern
+                #     # links.append(f"{self.base_api_url}/item/{item_id}") 
+                # For this placeholder, let's assume we are looking for direct URLs.
+                pass 
+        
+        if not links and items_list: # If we had items but extracted no links
+            logger.warning("Items found in API response, but no 'url_detalle_api' or similar field found in items for Santa Fe.")
+        elif not items_list:
+             logger.info("No items list found in API response to extract links from for Santa Fe.")
+        else:
+            logger.info(f"Extracted {len(links)} potential links/identifiers (placeholder) for Santa Fe.")
+        return links
+
+    async def get_next_page_url(self, api_response: Any, current_url: str) -> Optional[str]:
+        """
+        Determines the URL for the next page of results from an API response.
+        
+        Args:
+            api_response: The current API response.
+            current_url: The URL that yielded the current response.
+            
+        Returns:
+            The URL for the next page, or None if there is no next page.
+        """
+        logger.info(f"Attempting to determine next page URL for Santa Fe from current_url: {current_url}")
+        logger.warning("Placeholder implementation for SantaFeProvinciaScraper.get_next_page_url. API pagination details are needed.")
+        
+        if not isinstance(api_response, dict):
+            logger.warning("Cannot determine next page: API response is not a dictionary for Santa Fe.")
+            return None
+
+        # Placeholder: Assume pagination info is in the response body under a 'pagination' key
+        pagination_info = api_response.get("pagination", {}) # Placeholder key
+        if not isinstance(pagination_info, dict):
+            pagination_info = api_response.get("paging", {}) # Another common key
+            if not isinstance(pagination_info, dict):
+                logger.warning("No 'pagination' or 'paging' object found in API response for Santa Fe.")
+                # Try to find directly if keys are at root
+                # next_page_url = api_response.get("next_page_url_api") or api_response.get("nextLink")
+
+        next_page_url = pagination_info.get("next_page_url_api") # Placeholder key
+        if not next_page_url:
+             next_page_url = pagination_info.get("nextLink") # Common in some APIs like OData
+
+        if next_page_url and isinstance(next_page_url, str):
+            logger.info(f"Found next page URL in API response for Santa Fe: {next_page_url}")
+            # Ensure it's a full URL, some APIs return relative paths
+            # from urllib.parse import urljoin
+            # if not next_page_url.startswith(('http://', 'https://')):
+            #     next_page_url = urljoin(self.base_api_url or current_url, next_page_url)
+            return next_page_url
+        
+        # Alternative: Page number based pagination
+        # current_page = pagination_info.get("currentPage", pagination_info.get("pageNumber"))
+        # total_pages = pagination_info.get("totalPages", pagination_info.get("numPages"))
+        # if current_page is not None and total_pages is not None and current_page < total_pages:
+        #     # This requires knowing how the API constructs page URLs (e.g., ?page=N)
+        #     # from urllib.parse import urlparse, urlunparse, parse_qs, urlencode
+        #     # parsed_url = urlparse(current_url)
+        #     # query_params = parse_qs(parsed_url.query)
+        #     # query_params['page'] = [str(current_page + 1)] # Or relevant page parameter name
+        #     # new_query = urlencode(query_params, doseq=True)
+        #     # next_page_url = urlunparse(parsed_url._replace(query=new_query))
+        #     # logger.info(f"Calculated next page for Santa Fe based on page number (placeholder): {next_page_url}")
+        #     # return next_page_url
+        #     pass
+
+        logger.info("No next page URL found or determined by SantaFeProvinciaScraper (placeholder).")
+        return None
+
+# Example usage (for testing purposes, would not be part of the final scraper file usually)
+# if __name__ == '__main__':
+#     # This part would require an async environment to run properly
+#     # import asyncio
+#     scraper = SantaFeProvinciaScraper()
+    
+#     # Mock API data item (replace with actual structure when known)
+#     mock_api_item = {
+#         "id_api": "SF-LIC-2023-0001",
+#         "titulo_api": "Adquisicion de Insumos Medicos Hospital Cullen",
+#         "organismo_api": "Ministerio de Salud de Santa Fe",
+#         "fecha_publicacion_api": "2023-11-20T10:00:00Z",
+#         "numero_expediente_api": "EXP-MSF-001234-2023",
+#         "objeto_licitacion_api": "Compra de jeringas, gasas y otros insumos.",
+#         "estado_api": "Publicada",
+#         "monto_oficial_api": "5300250.75",
+#         "tipo_contratacion_api": "Licitación Pública",
+#         "lugar_entrega_api": "Hospital Cullen, Santa Fe Ciudad",
+#         "url_detalle_api": "https://api.santafe.gob.ar/licitaciones/SF-LIC-2023-0001" # Example
+#     }
+    
+#     # Mock API list response
+#     mock_api_list_response = {
+#         "data": [
+#             mock_api_item,
+#             {**mock_api_item, "id_api": "SF-LIC-2023-0002", "url_detalle_api": "https://api.santafe.gob.ar/licitaciones/SF-LIC-2023-0002"}
+#         ],
+#         "pagination": {
+#             "currentPage": 1,
+#             "totalPages": 3,
+#             "next_page_url_api": "https://api.santafe.gob.ar/licitaciones?page=2" # Example
+#         }
+#     }
+
+#     async def main():
+#         print("--- Testing extract_licitacion_data ---")
+#         licitacion = await scraper.extract_licitacion_data(mock_api_item, mock_api_item["url_detalle_api"])
+#         if licitacion:
+#             print("Extracted Licitacion (from mock API item - using placeholder fields):")
+#             print(licitacion.model_dump_json(indent=2))
+#         else:
+#             print("Licitacion extraction failed from mock API item.")
+
+#         print("\n--- Testing extract_links ---")
+#         links = await scraper.extract_links(mock_api_list_response)
+#         print(f"Extracted links (using placeholder logic): {links}")
+        
+#         print("\n--- Testing get_next_page_url ---")
+#         next_page = await scraper.get_next_page_url(mock_api_list_response, "https://api.santafe.gob.ar/licitaciones?page=1")
+#         print(f"Next page URL (using placeholder logic): {next_page}")
+
+#     # asyncio.run(main())
+```

--- a/backend/scrapers/scraper_factory.py
+++ b/backend/scrapers/scraper_factory.py
@@ -8,16 +8,46 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from models.scraper_config import ScraperConfig
 from scrapers.base_scraper import BaseScraper
 from scrapers.comprar_gob_ar import ComprarGobArScraper
-from scrapers.mendoza_compra import MendozaCompraScraper
+# Existing specific scrapers
+from scrapers.mendoza_compra import MendozaCompraScraper # Keep for now as per instructions
+
+# Newly added scrapers
+from backend.scrapers.buenos_aires_provincia_scraper import BuenosAiresProvinciaScraper
+from backend.scrapers.caba_scraper import CabaScraper
+from backend.scrapers.cordoba_provincia_scraper import CordobaProvinciaScraper
+from backend.scrapers.santa_fe_provincia_scraper import SantaFeProvinciaScraper
+from backend.scrapers.mendoza_provincia_scraper import MendozaProvinciaScraper
+
 
 def create_scraper(config: ScraperConfig) -> Optional[BaseScraper]:
     """Create a scraper based on the configuration"""
     
+    # Normalize name for easier matching
+    config_name_lower = config.name.lower()
+
     # Check for known scrapers by URL or name
-    if "comprar.gob.ar" in config.url:
+    # Ordered from more specific URL patterns where possible, then by name
+    if "comprar.gob.ar" in config.url and "comprar" in config_name_lower: # Existing ComprarGobArScraper
         return ComprarGobArScraper(config)
-    elif "mendoza.gov.ar" in config.url or "mendoza-compra" in config.url.lower():
+    
+    # New Scrapers
+    elif "compras.gba.gob.ar" in config.url or "buenos-aires-provincia" in config_name_lower:
+        return BuenosAiresProvinciaScraper(config)
+    elif "buenosairescompras.gob.ar" in config.url or "caba" in config_name_lower:
+        return CabaScraper(config)
+    elif "compras.cba.gov.ar" in config.url or "cordoba-provincia" in config_name_lower:
+        return CordobaProvinciaScraper(config)
+    elif "santafe.gov.ar/portal_compras" in config.url or "santa-fe-provincia" in config_name_lower:
+        return SantaFeProvinciaScraper(config)
+    # New Mendoza scraper - specific URL first
+    elif "comprar.mendoza.gov.ar" in config.url or "mendoza-provincia" in config_name_lower: # This is for the new OCDS-focused one
+        return MendozaProvinciaScraper(config)
+    
+    # Existing Mendoza scraper (potentially more general or different part of mendoza.gov.ar)
+    elif "mendoza.gov.ar" in config.url or "mendoza-compra" in config_name_lower: # Keep this for MendozaCompraScraper
         return MendozaCompraScraper(config)
     
-    # For unknown URLs, use a generic scraper (not implemented yet)
+    # For unknown URLs or names, log or raise error, or return None
+    # For now, returning None as per original structure for unhandled cases.
+    # Consider adding logging here: logger.warning(f"No specific scraper found for URL {config.url} or name {config.name}")
     return None

--- a/tests/scrapers/test_buenos_aires_provincia_scraper.py
+++ b/tests/scrapers/test_buenos_aires_provincia_scraper.py
@@ -1,0 +1,164 @@
+import unittest
+import asyncio
+from datetime import datetime
+from typing import Optional, List, Any
+
+from pydantic import HttpUrl
+
+# Corrected import paths assuming 'backend' is a top-level package for models and scrapers
+# and 'tests' is at the same level as 'backend'.
+# This requires __init__.py in relevant directories and proper PYTHONPATH setup if run directly.
+# For a typical project structure where tests are outside the main package, adjustments might be needed
+# or running via a test runner that handles paths (e.g. python -m unittest)
+from backend.models.scraper_config import ScraperConfig
+from backend.models.licitacion import LicitacionCreate
+from backend.scrapers.buenos_aires_provincia_scraper import BuenosAiresProvinciaScraper
+
+
+class TestBuenosAiresProvinciaScraper(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        """Set up test environment for BuenosAiresProvinciaScraper."""
+        self.config = ScraperConfig(
+            name="Buenos Aires Provincia Test",
+            url="https://mock.api.gba.gob.ar/licitaciones", # Placeholder API URL
+            frequency_seconds=3600,
+            module_path="backend.scrapers.buenos_aires_provincia_scraper", # For reference
+            enabled=True,
+            headers={"User-Agent": "Test Scraper"},
+            params={"param1": "value1"}
+        )
+        # Assuming BuenosAiresProvinciaScraper is updated to accept config
+        # If not, this line would need to be self.scraper = BuenosAiresProvinciaScraper()
+        # And the scraper's __init__ would need to match.
+        # Based on factory changes, it should accept config.
+        self.scraper = BuenosAiresProvinciaScraper(self.config)
+        # self.scraper = BuenosAiresProvinciaScraper() # Use this if scraper __init__ doesn't take config
+
+    async def test_extract_licitacion_data_api_success(self):
+        """Test successful data extraction from a mock API response."""
+        mock_api_response = {
+            "id_licitacion_api": "BAP_LIC_2023_001",
+            "titulo_api": "Construcción de Escuela Primaria Nro 123",
+            "organismo_api": "Dirección General de Cultura y Educación PBA",
+            "jurisdiccion_api": "Provincia de Buenos Aires",
+            "fecha_publicacion_api": "2023-10-15T10:00:00", # ISO format
+            "numero_licitacion_api": "EXP-2023-0012345-GDEBA-DGCYE",
+            "estado_licitacion_api": "Publicada",
+            "monto_estimado_api": "12500000.75", # String, to be converted to float
+            "tipo_procedimiento_api": "Licitación Pública",
+            "tipo_acceso_api": "Electrónico",
+            "municipios_cubiertos_api": "La Plata, Berazategui",
+            "descripcion_api": "Obra completa para la nueva escuela." # Added for completeness if LicitacionBase needs it
+        }
+        mock_url = "https://mock.api.gba.gob.ar/licitaciones/BAP_LIC_2023_001"
+
+        licitacion = await self.scraper.extract_licitacion_data(mock_api_response, mock_url)
+
+        self.assertIsNotNone(licitacion)
+        self.assertIsInstance(licitacion, LicitacionCreate)
+
+        self.assertEqual(licitacion.id_licitacion, "BAP_LIC_2023_001")
+        self.assertEqual(licitacion.title, "Construcción de Escuela Primaria Nro 123")
+        self.assertEqual(licitacion.organization, "Dirección General de Cultura y Educación PBA")
+        self.assertEqual(licitacion.jurisdiccion, "Provincia de Buenos Aires")
+        
+        expected_publication_date = datetime(2023, 10, 15, 10, 0, 0)
+        self.assertEqual(licitacion.publication_date, expected_publication_date)
+        
+        self.assertEqual(licitacion.licitacion_number, "EXP-2023-0012345-GDEBA-DGCYE")
+        self.assertEqual(licitacion.status, "Publicada")
+        self.assertEqual(licitacion.budget, 12500000.75)
+        self.assertEqual(licitacion.source_url, HttpUrl(mock_url))
+        self.assertEqual(licitacion.tipo_procedimiento, "Licitación Pública")
+        self.assertEqual(licitacion.tipo_acceso, "Electrónico")
+        self.assertEqual(licitacion.municipios_cubiertos, "La Plata, Berazategui")
+        
+        # fecha_scraping is set to datetime.now(), so we check its type
+        self.assertIsInstance(licitacion.fecha_scraping, datetime)
+        # description is an optional field in LicitacionBase, ensure it's handled
+        # The scraper current placeholder does not map description_api, so it should be None
+        # If it were mapped: self.assertEqual(licitacion.description, "Obra completa para la nueva escuela.")
+        self.assertIsNone(licitacion.description) # Based on current scraper impl.
+
+    async def test_extract_licitacion_data_api_failure_missing_required(self):
+        """Test extraction failure when required API data is missing."""
+        mock_api_response_missing = {
+            # Missing "id_licitacion_api", "titulo_api", etc.
+            "organismo_api": "Dirección General de Cultura y Educación PBA",
+            "fecha_publicacion_api": "2023-10-15T10:00:00",
+        }
+        mock_url = "https://mock.api.gba.gob.ar/licitaciones/BAP_LIC_FAIL_002"
+        
+        # The current scraper implementation fills missing required fields with "_UNKNOWN"
+        # and does not return None unless the input `data` is not a dict.
+        # So, we expect an object, but with placeholder values for critical fields.
+        licitacion = await self.scraper.extract_licitacion_data(mock_api_response_missing, mock_url)
+        
+        self.assertIsNotNone(licitacion) # It will return an object
+        self.assertTrue(licitacion.id_licitacion.endswith("_UNKNOWN"))
+        self.assertTrue(licitacion.title.endswith("_UNKNOWN"))
+        # ... and so on for other fields that would be missing and are required by LicitacionCreate.
+
+    async def test_extract_licitacion_data_api_failure_bad_types(self):
+        """Test extraction failure with incorrect data types from API."""
+        mock_api_response_bad_type = {
+            "id_licitacion_api": "BAP_LIC_BAD_003",
+            "titulo_api": "Test Bad Types",
+            "organismo_api": "Test Org",
+            "jurisdiccion_api": "Test Juris",
+            "fecha_publicacion_api": "esto-no-es-una-fecha", # Invalid date format
+            "numero_licitacion_api": "NUM-BAD-003",
+            "estado_licitacion_api": "Estado Malo",
+            "monto_estimado_api": "unmillon", # Invalid float
+            "tipo_procedimiento_api": "Procedimiento Malo",
+        }
+        mock_url = "https://mock.api.gba.gob.ar/licitaciones/BAP_LIC_BAD_003"
+
+        licitacion = await self.scraper.extract_licitacion_data(mock_api_response_bad_type, mock_url)
+        
+        self.assertIsNotNone(licitacion) # Scraper tries to parse, defaults on failure
+        self.assertNotEqual(licitacion.publication_date, datetime(1,1,1)) # Default is now()
+        self.assertIsInstance(licitacion.publication_date, datetime) # Should default to now()
+        self.assertIsNone(licitacion.budget) # Parsing "unmillon" to float fails, results in None
+
+    async def test_extract_licitacion_data_not_dict(self):
+        """Test extraction failure when input data is not a dictionary."""
+        mock_api_response_not_dict = "This is a string, not a dict"
+        mock_url = "https://mock.api.gba.gob.ar/licitaciones/BAP_LIC_NOT_DICT"
+        
+        licitacion = await self.scraper.extract_licitacion_data(mock_api_response_not_dict, mock_url)
+        self.assertIsNone(licitacion) # Scraper should return None if data is not dict
+
+    async def test_extract_links_placeholder(self):
+        """Test placeholder implementation of extract_links."""
+        # Placeholder expects a list or dict, returns [] if not matching or empty
+        mock_api_response_for_links = {"items": [{"detail_url_api": "url1"}, {"no_url": "data"}]} 
+        links = await self.scraper.extract_links(mock_api_response_for_links)
+        self.assertEqual(links, ["url1"])
+
+        links_empty = await self.scraper.extract_links([])
+        self.assertEqual(links_empty, [])
+        
+        links_bad_format = await self.scraper.extract_links("not a list or dict")
+        self.assertEqual(links_bad_format, [])
+
+
+    async def test_get_next_page_url_placeholder(self):
+        """Test placeholder implementation of get_next_page_url."""
+        mock_api_response_with_next = {
+            "pagination": {"next_page_url_api": "https://mock.api.gba.gob.ar/licitaciones?page=2"}
+        }
+        next_url = await self.scraper.get_next_page_url(mock_api_response_with_next, self.config.url)
+        self.assertEqual(next_url, "https://mock.api.gba.gob.ar/licitaciones?page=2")
+
+        mock_api_response_no_next = {"pagination": {"other_info": "data"}}
+        next_url_none = await self.scraper.get_next_page_url(mock_api_response_no_next, self.config.url)
+        self.assertIsNone(next_url_none)
+
+        next_url_bad_format = await self.scraper.get_next_page_url("not a dict", self.config.url)
+        self.assertIsNone(next_url_bad_format)
+
+if __name__ == '__main__':
+    unittest.main()
+```

--- a/tests/scrapers/test_caba_scraper.py
+++ b/tests/scrapers/test_caba_scraper.py
@@ -1,0 +1,144 @@
+import unittest
+import asyncio
+from datetime import datetime
+from typing import Optional, List, Any
+
+from pydantic import HttpUrl
+from bs4 import BeautifulSoup # For HTML context, though not deeply used by placeholder tests
+
+from backend.models.scraper_config import ScraperConfig
+from backend.models.licitacion import LicitacionCreate
+from backend.scrapers.caba_scraper import CabaScraper
+
+
+class TestCabaScraper(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        """Set up test environment for CabaScraper."""
+        self.config = ScraperConfig(
+            name="CABA Test",
+            url="https://mock.api.caba.gob.ar/compras", # Placeholder API/HTML URL
+            frequency_seconds=3600,
+            module_path="backend.scrapers.caba_scraper",
+            enabled=True,
+            headers={"User-Agent": "Test Scraper CABA"},
+        )
+        # Assuming CabaScraper's __init__ is updated to accept config
+        self.scraper = CabaScraper(self.config)
+        # self.scraper = CabaScraper() # Fallback if __init__ not updated
+
+    async def test_extract_licitacion_data_api_success(self):
+        """Test successful data extraction from a mock API response."""
+        mock_api_response = {
+            "id_licitacion_api": "CABA_LIC_2023_001",
+            "titulo_api": "Servicio de Limpieza Edificios Gubernamentales",
+            "organismo_api": "Secretaría General GCBA",
+            "jurisdiccion_api": "Ciudad Autónoma de Buenos Aires",
+            "fecha_publicacion_api": "2023-11-01T12:00:00Z",
+            "numero_licitacion_api": "LIC-GCBA-SG-001-23",
+            "descripcion_api": "Contratación de servicio de limpieza integral.",
+            "estado_licitacion_api": "Publicada",
+            "monto_estimado_api": "2500000.75",
+            "tipo_procedimiento_api": "Licitación Pública Nacional",
+            "tipo_acceso_api": "BAC Compras",
+        }
+        mock_url = "https://mock.api.caba.gob.ar/compras/item/CABA_LIC_2023_001"
+
+        licitacion = await self.scraper.extract_licitacion_data(mock_api_response, mock_url)
+
+        self.assertIsNotNone(licitacion)
+        self.assertIsInstance(licitacion, LicitacionCreate)
+
+        self.assertEqual(licitacion.id_licitacion, "CABA_LIC_2023_001")
+        self.assertEqual(licitacion.title, "Servicio de Limpieza Edificios Gubernamentales")
+        self.assertEqual(licitacion.organization, "Secretaría General GCBA")
+        self.assertEqual(licitacion.jurisdiccion, "Ciudad Autónoma de Buenos Aires")
+        
+        expected_publication_date = datetime(2023, 11, 1, 12, 0, 0) # Assuming Z means UTC
+        self.assertEqual(licitacion.publication_date, expected_publication_date)
+        
+        self.assertEqual(licitacion.licitacion_number, "LIC-GCBA-SG-001-23")
+        self.assertEqual(licitacion.description, "Contratación de servicio de limpieza integral.")
+        self.assertEqual(licitacion.status, "Publicada")
+        self.assertEqual(licitacion.budget, 2500000.75)
+        self.assertEqual(licitacion.source_url, HttpUrl(mock_url))
+        self.assertEqual(licitacion.tipo_procedimiento, "Licitación Pública Nacional")
+        self.assertEqual(licitacion.tipo_acceso, "BAC Compras")
+        
+        self.assertIsInstance(licitacion.fecha_scraping, datetime)
+
+    async def test_extract_licitacion_data_api_failure(self):
+        """Test extraction with incomplete/malformed API data."""
+        mock_api_response_incomplete = {
+            "titulo_api": "Servicio Incompleto",
+            # Missing id_licitacion_api, organismo_api, etc.
+            "monto_estimado_api": "quinientosmil", # Malformed
+        }
+        mock_url = "https://mock.api.caba.gob.ar/compras/item/CABA_LIC_FAIL_002"
+
+        licitacion = await self.scraper.extract_licitacion_data(mock_api_response_incomplete, mock_url)
+        
+        self.assertIsNotNone(licitacion) # Scraper currently returns object with defaults
+        self.assertTrue(licitacion.id_licitacion.endswith("_UNKNOWN"))
+        self.assertEqual(licitacion.title, "Servicio Incompleto")
+        self.assertTrue(licitacion.organization.endswith("_UNKNOWN"))
+        self.assertIsNone(licitacion.budget) # "quinientosmil" fails to parse
+
+    async def test_extract_licitacion_data_html_placeholder(self):
+        """Test placeholder behavior for HTML data extraction."""
+        mock_html_content = """
+        <html><body><h1>Contratación Directa</h1><p>ID: HTML_ID_001</p></body></html>
+        """
+        mock_url = "https://mock.caba.gob.ar/compras/html/HTML_ID_001"
+
+        licitacion = await self.scraper.extract_licitacion_data(mock_html_content, mock_url)
+
+        # Current CabaScraper HTML path is a placeholder: it logs a warning,
+        # extracts no fields from HTML, then proceeds to LicitacionCreate with defaults.
+        self.assertIsNotNone(licitacion)
+        self.assertIsInstance(licitacion, LicitacionCreate)
+        self.assertTrue(licitacion.id_licitacion.endswith("_UNKNOWN")) # Since HTML parsing is placeholder
+        self.assertTrue(licitacion.title.endswith("_UNKNOWN"))
+        # ... and so on for other fields. They will be the "_UNKNOWN" default versions.
+        self.assertEqual(licitacion.source_url, HttpUrl(mock_url))
+        self.assertIsInstance(licitacion.fecha_scraping, datetime)
+
+    async def test_extract_licitacion_data_invalid_input_type(self):
+        """Test extraction failure when input data is not dict or str."""
+        mock_invalid_input = 12345 # Neither dict nor string
+        mock_url = "https://mock.api.caba.gob.ar/compras/item/CABA_LIC_INVALID"
+        
+        licitacion = await self.scraper.extract_licitacion_data(mock_invalid_input, mock_url)
+        self.assertIsNone(licitacion) # Scraper should return None for invalid input type
+
+    async def test_extract_links_api_placeholder(self):
+        """Test placeholder implementation of extract_links for API data."""
+        mock_api_data = {"results": [{"detail_url": "url1"}, {"detail_url": "url2"}]}
+        # Current placeholder for CabaScraper.extract_links returns [] as it's not implemented
+        links = await self.scraper.extract_links(mock_api_data)
+        self.assertEqual(links, [])
+
+    async def test_extract_links_html_placeholder(self):
+        """Test placeholder implementation of extract_links for HTML data."""
+        mock_html_content = "<a href='link1.html'>1</a> <a href='link2.html'>2</a>"
+        # Current placeholder for CabaScraper.extract_links returns []
+        links = await self.scraper.extract_links(mock_html_content)
+        self.assertEqual(links, [])
+
+    async def test_get_next_page_url_api_placeholder(self):
+        """Test placeholder implementation of get_next_page_url for API data."""
+        mock_api_data = {"pagination": {"next_page_url": "api.example.com?page=2"}}
+        # Current placeholder for CabaScraper.get_next_page_url returns None
+        next_url = await self.scraper.get_next_page_url(mock_api_data, self.config.url)
+        self.assertIsNone(next_url)
+
+    async def test_get_next_page_url_html_placeholder(self):
+        """Test placeholder implementation of get_next_page_url for HTML data."""
+        mock_html_content = "<a class='next' href='page2.html'>Next</a>"
+        # Current placeholder for CabaScraper.get_next_page_url returns None
+        next_url = await self.scraper.get_next_page_url(mock_html_content, self.config.url)
+        self.assertIsNone(next_url)
+
+if __name__ == '__main__':
+    unittest.main()
+```

--- a/tests/scrapers/test_cordoba_provincia_scraper.py
+++ b/tests/scrapers/test_cordoba_provincia_scraper.py
@@ -1,0 +1,166 @@
+import unittest
+import asyncio
+from datetime import datetime
+from typing import Optional, List, Any
+
+from pydantic import HttpUrl
+from bs4 import BeautifulSoup
+
+from backend.models.scraper_config import ScraperConfig
+from backend.models.licitacion import LicitacionCreate
+from backend.scrapers.cordoba_provincia_scraper import CordobaProvinciaScraper
+
+
+class TestCordobaProvinciaScraper(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        """Set up test environment for CordobaProvinciaScraper."""
+        self.config = ScraperConfig(
+            name="Cordoba Provincia Test",
+            url="https://mock.compras.cba.gov.ar/portal", # Main portal URL
+            frequency_seconds=3600,
+            module_path="backend.scrapers.cordoba_provincia_scraper",
+            enabled=True,
+            headers={"User-Agent": "Test Scraper Cordoba"},
+        )
+        # Assuming CordobaProvinciaScraper's __init__ is updated to accept config
+        self.scraper = CordobaProvinciaScraper(self.config)
+        # The scraper uses self.base_url for urljoin, let's ensure it's set for tests
+        # Typically, the scraper would set this from config.url or a hardcoded value.
+        # The CordobaProvinciaScraper has a hardcoded placeholder for self.base_url.
+        # We can override it here for deterministic tests if needed, or rely on its default.
+        # self.scraper.base_url = "https://compraspublicas.cba.gov.ar/" # Example of overriding
+        # For this test, we'll rely on the scraper's own placeholder base_url or ensure config.url is used.
+        # The scraper's current __init__ hardcodes `self.base_url = "https://placeholder.cordoba.gov.ar"`
+        # So, link joining will use that.
+
+    async def test_extract_licitacion_data_html_success(self):
+        """Test successful data extraction from mock HTML matching placeholder selectors."""
+        # This HTML is crafted to match the *placeholder selectors* in CordobaProvinciaScraper
+        mock_html_content = """
+        <html><body>
+            <h1 class='licitacion-titulo'>Adquisición de Equipamiento Médico</h1>
+            <div class='licitacion-id'><label>ID:</label><span class='valor'>LIC-CBA-2023-001</span></div>
+            <div class='info-organismo'><p>Ministerio de Salud de Córdoba</p></div>
+            <span class='fecha-publicacion'>2023-11-10T10:00:00</span>
+            <div class='numero-expediente'><label>Expediente:</label><span class='valor'>EXP-2023-ABC-01</span></div>
+            <div class='descripcion-licitacion'>Equipamiento completo para nuevo hospital regional.</div>
+            <span class='estado-actual'>Abierta</span>
+            <div class='monto-estimado'><label>Monto:</label><span class='valor'>$ 2.500.000,50</span></div>
+            <div class='tipo-procedimiento'><label>Tipo:</label><span class='valor'>Licitación Pública Nacional</span></div>
+            <div class='municipios'><label>Cobertura:</label><span class='valor'>Toda la provincia</span></div>
+        </body></html>
+        """
+        mock_url = f"{self.scraper.base_url}/detalle/LIC-CBA-2023-001"
+
+        licitacion = await self.scraper.extract_licitacion_data(mock_html_content, mock_url)
+
+        self.assertIsNotNone(licitacion)
+        self.assertIsInstance(licitacion, LicitacionCreate)
+
+        self.assertEqual(licitacion.id_licitacion, "LIC-CBA-2023-001")
+        self.assertEqual(licitacion.title, "Adquisición de Equipamiento Médico")
+        self.assertEqual(licitacion.organization, "Ministerio de Salud de Córdoba")
+        self.assertEqual(licitacion.jurisdiccion, "Córdoba Provincia") # Hardcoded in scraper
+        
+        expected_publication_date = datetime(2023, 11, 10, 10, 0, 0)
+        self.assertEqual(licitacion.publication_date, expected_publication_date)
+        
+        self.assertEqual(licitacion.licitacion_number, "EXP-2023-ABC-01")
+        self.assertEqual(licitacion.description, "Equipamiento completo para nuevo hospital regional.")
+        self.assertEqual(licitacion.status, "Abierta")
+        self.assertEqual(licitacion.budget, 2500000.50) # Parsed from '$ 2.500.000,50'
+        self.assertEqual(licitacion.source_url, HttpUrl(mock_url))
+        self.assertEqual(licitacion.tipo_procedimiento, "Licitación Pública Nacional")
+        self.assertEqual(licitacion.tipo_acceso, "Web scraping") # Hardcoded in scraper
+        self.assertEqual(licitacion.municipios_cubiertos, "Toda la provincia")
+        
+        self.assertIsInstance(licitacion.fecha_scraping, datetime)
+
+    async def test_extract_licitacion_data_html_incomplete(self):
+        """Test HTML data extraction when some elements are missing."""
+        mock_html_content = """
+        <html><body>
+            <h1 class='licitacion-titulo'>Título Incompleto</h1>
+            <div class='licitacion-id'><span class='valor'>LIC-INC-002</span></div>
+            {/* Missing organism, fecha_publicacion, etc. */}
+        </body></html>
+        """
+        mock_url = f"{self.scraper.base_url}/detalle/LIC-INC-002"
+        licitacion = await self.scraper.extract_licitacion_data(mock_html_content, mock_url)
+
+        self.assertIsNotNone(licitacion)
+        self.assertEqual(licitacion.id_licitacion, "LIC-INC-002")
+        self.assertEqual(licitacion.title, "Título Incompleto")
+        self.assertTrue(licitacion.organization.endswith("_UNKNOWN")) # Defaulted
+        self.assertIsInstance(licitacion.publication_date, datetime) # Defaults to now()
+        self.assertIsNone(licitacion.budget) # Missing element
+
+    async def test_extract_licitacion_data_html_malformed(self):
+        """Test HTML data extraction with malformed date and budget values."""
+        mock_html_content = """
+        <html><body>
+            <h1 class='licitacion-titulo'>Test Malformed</h1>
+            <div class='licitacion-id'><span class='valor'>LIC-MAL-003</span></div>
+            <span class='fecha-publicacion'>Esto no es una fecha</span>
+            <div class='monto-estimado'><span class='valor'>cien pesos</span></div>
+            <div class='info-organismo'><p>Org Test</p></div>
+            <div class='numero-expediente'><span class='valor'>N/A</span></div>
+             <span class='estado-actual'>Activa</span>
+            <div class='tipo-procedimiento'><span class='valor'>Alguno</span></div>
+        </body></html>
+        """
+        mock_url = f"{self.scraper.base_url}/detalle/LIC-MAL-003"
+        licitacion = await self.scraper.extract_licitacion_data(mock_html_content, mock_url)
+        
+        self.assertIsNotNone(licitacion)
+        self.assertEqual(licitacion.id_licitacion, "LIC-MAL-003")
+        self.assertIsInstance(licitacion.publication_date, datetime) # Defaults to now()
+        self.assertIsNone(licitacion.budget) # "cien pesos" fails to parse
+
+    async def test_extract_links_html_placeholder(self):
+        """Test HTML link extraction using placeholder selectors."""
+        # Assumes self.scraper.base_url is "https://placeholder.cordoba.gov.ar" from scraper's __init__
+        mock_listing_html = f"""
+        <html><body>
+            <a class="placeholder-licitacion-link-selector" href="/detalle/lic1">Licitacion 1</a>
+            <a class="placeholder-licitacion-link-selector" href="https://externo.com/lic2">Licitacion 2 Externa</a>
+            <a class="other-link" href="/no-select">No Select</a>
+            <a class="placeholder-licitacion-link-selector" href="detalle/lic3_relative_path">Licitacion 3 Relative</a>
+        </body></html>
+        """
+        expected_links = [
+            f"{self.scraper.base_url}/detalle/lic1",
+            "https://externo.com/lic2", # Absolute URL should remain unchanged
+            f"{self.scraper.base_url}/detalle/lic3_relative_path"
+        ]
+        links = await self.scraper.extract_links(mock_listing_html)
+        self.assertListEqual(links, expected_links)
+
+    async def test_get_next_page_url_html_placeholder(self):
+        """Test HTML next page URL extraction using placeholder selectors."""
+        mock_pagination_html = f"""
+        <html><body>
+            <a class="placeholder-next-page-selector" href="?page=2">Siguiente</a>
+        </body></html>
+        """
+        # current_url for context, though not strictly used by urljoin if href is relative path without domain
+        current_page_url = f"{self.scraper.base_url}/listado?page=1" 
+        expected_next_url = f"{self.scraper.base_url}/listado?page=2" # urljoin behavior with path
+        
+        # Need to adjust expectation if href is just "?page=2"
+        # urljoin("https://placeholder.cordoba.gov.ar/listado?page=1", "?page=2") -> "https://placeholder.cordoba.gov.ar/listado?page=2"
+        
+        next_url = await self.scraper.get_next_page_url(mock_pagination_html, current_page_url)
+        self.assertEqual(next_url, expected_next_url)
+
+    async def test_get_next_page_url_html_no_link_placeholder(self):
+        """Test HTML next page URL extraction when no link matches placeholder."""
+        mock_no_pagination_html = "<html><body><p>No hay más páginas</p></body></html>"
+        current_page_url = f"{self.scraper.base_url}/listado?page=10"
+        next_url = await self.scraper.get_next_page_url(mock_no_pagination_html, current_page_url)
+        self.assertIsNone(next_url)
+
+if __name__ == '__main__':
+    unittest.main()
+```

--- a/tests/scrapers/test_mendoza_provincia_scraper.py
+++ b/tests/scrapers/test_mendoza_provincia_scraper.py
@@ -1,0 +1,172 @@
+import unittest
+import asyncio
+from datetime import datetime, timezone
+from typing import Optional, List, Any
+
+from pydantic import HttpUrl
+
+from backend.models.scraper_config import ScraperConfig
+from backend.models.licitacion import LicitacionCreate
+from backend.scrapers.mendoza_provincia_scraper import MendozaProvinciaScraper
+
+
+class TestMendozaProvinciaScraper(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        """Set up test environment for MendozaProvinciaScraper."""
+        self.config = ScraperConfig(
+            name="Mendoza Provincia Test",
+            url="https://mock.api.mendoza.gob.ar/ocds/releases", # Placeholder OCDS API URL
+            frequency_seconds=3600,
+            module_path="backend.scrapers.mendoza_provincia_scraper",
+            enabled=True,
+            headers={"User-Agent": "Test Scraper Mendoza"},
+        )
+        # Assuming MendozaProvinciaScraper's __init__ is updated to accept config
+        self.scraper = MendozaProvinciaScraper(self.config)
+        # self.scraper.base_api_url = self.config.url # Potentially set if scraper uses it
+
+    async def test_extract_licitacion_data_ocds_release_success(self):
+        """Test successful data extraction from a mock OCDS release structure."""
+        mock_ocds_release = {
+            "ocid": "ocds-xxxxx-001",
+            "id": "release-001", # Release ID
+            "date": "2023-11-01T10:00:00Z",
+            "tag": ["tender"],
+            "buyer": {
+                "id": "buyer-01",
+                "name": "Ministerio de Compras Públicas de Mendoza"
+            },
+            "tender": {
+                "id": "tender-xyz-001", # Tender ID
+                "title": "Adquisición de Equipamiento Informático Avanzado",
+                "description": "Licitación para la compra de servidores y workstations.",
+                "status": "active",
+                "value": {
+                    "amount": 5500000.50,
+                    "currency": "ARS"
+                },
+                "procurementMethod": "open",
+                "procurementMethodDetails": "Licitación Pública Nacional",
+                "datePublished": "2023-10-15T12:00:00Z",
+                # "items": [{"deliveryAddress": {"locality": "Godoy Cruz"}}] # Example for municipios_cubiertos
+            }
+        }
+        mock_url = "https://mock.api.mendoza.gob.ar/ocds/release/ocds-xxxxx-001"
+
+        licitacion = await self.scraper.extract_licitacion_data(mock_ocds_release, mock_url)
+
+        self.assertIsNotNone(licitacion)
+        self.assertIsInstance(licitacion, LicitacionCreate)
+
+        self.assertEqual(licitacion.id_licitacion, "ocds-xxxxx-001") # Uses OCID
+        self.assertEqual(licitacion.title, "Adquisición de Equipamiento Informático Avanzado")
+        self.assertEqual(licitacion.organization, "Ministerio de Compras Públicas de Mendoza")
+        self.assertEqual(licitacion.jurisdiccion, "Mendoza Provincia") # Defaulted by scraper
+        
+        expected_publication_date = datetime(2023, 10, 15, 12, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(licitacion.publication_date, expected_publication_date)
+        
+        self.assertEqual(licitacion.licitacion_number, "tender-xyz-001") # tender.id
+        self.assertEqual(licitacion.description, "Licitación para la compra de servidores y workstations.")
+        self.assertEqual(licitacion.status, "active")
+        self.assertEqual(licitacion.budget, 5500000.50)
+        self.assertEqual(licitacion.currency, "ARS")
+        self.assertEqual(licitacion.source_url, HttpUrl(mock_url))
+        self.assertEqual(licitacion.tipo_procedimiento, "Licitación Pública Nacional")
+        self.assertEqual(licitacion.tipo_acceso, "API/OCDS") # Hardcoded by scraper
+        self.assertIsNone(licitacion.municipios_cubiertos) # Not directly mapped from standard OCDS in placeholder
+        
+        self.assertIsInstance(licitacion.fecha_scraping, datetime)
+
+    async def test_extract_licitacion_data_direct_tender_success(self):
+        """Test successful data extraction when api_data is a direct tender object."""
+        mock_tender_object = {
+            # No OCID at this level, id_licitacion might come from tender.id or generic _api if available
+            "id": "tender-only-002", 
+            "title": "Servicio de Mantenimiento Edilicio",
+            "description": "Mantenimiento integral de edificios públicos.",
+            "status": "planned",
+            "value": {"amount": 120000.00, "currency": "USD"},
+            "procurementMethodDetails": "Contratación Directa",
+            "datePublished": "2023-11-20T09:30:00Z",
+            "procuringEntity": {"name": "Secretaría de Obras Mendoza"} # Alternative to buyer.name
+        }
+        mock_url = "https://mock.api.mendoza.gob.ar/ocds/tender/tender-only-002"
+        licitacion = await self.scraper.extract_licitacion_data(mock_tender_object, mock_url)
+
+        self.assertIsNotNone(licitacion)
+        self.assertEqual(licitacion.id_licitacion, "tender-only-002") # Falls back to tender.id
+        self.assertEqual(licitacion.title, "Servicio de Mantenimiento Edilicio")
+        self.assertEqual(licitacion.organization, "Secretaría de Obras Mendoza")
+        self.assertEqual(licitacion.status, "planned")
+        self.assertEqual(licitacion.budget, 120000.00)
+        self.assertEqual(licitacion.currency, "USD")
+
+    async def test_extract_licitacion_data_failure(self):
+        """Test extraction with incomplete/malformed OCDS/API data."""
+        mock_ocds_incomplete = {
+            "ocid": "ocds-incomplete-003",
+            "tender": {
+                "title": "Licitación Incompleta",
+                "value": {"amount": "doscientosmil"}, # Malformed budget
+                "datePublished": "ayer", # Malformed date
+            }
+        }
+        mock_url = "https://mock.api.mendoza.gob.ar/ocds/release/ocds-incomplete-003"
+        licitacion = await self.scraper.extract_licitacion_data(mock_ocds_incomplete, mock_url)
+        
+        self.assertIsNotNone(licitacion) # Scraper returns object with defaults
+        self.assertEqual(licitacion.id_licitacion, "ocds-incomplete-003")
+        self.assertEqual(licitacion.title, "Licitación Incompleta")
+        self.assertTrue(licitacion.organization.endswith("_UNKNOWN"))
+        self.assertIsNone(licitacion.budget) # "doscientosmil" fails parsing
+        self.assertIsInstance(licitacion.publication_date, datetime) # Defaults to now()
+
+    async def test_extract_licitacion_data_not_dict(self):
+        """Test extraction failure when input data is not a dictionary."""
+        mock_api_response_not_dict = "This is a plain string."
+        mock_url = "https://mock.api.mendoza.gob.ar/ocds/release/not-a-dict"
+        
+        licitacion = await self.scraper.extract_licitacion_data(mock_api_response_not_dict, mock_url)
+        self.assertIsNone(licitacion)
+
+    async def test_extract_links_ocds_placeholder(self):
+        """Test placeholder implementation of extract_links for OCDS Release Package."""
+        mock_ocds_package = {
+            "releases": [
+                {"ocid": "ocds-link-001"},
+                {"ocid": "ocds-link-002", "tender": {"title": "Some Tender"}}
+            ]
+        }
+        links = await self.scraper.extract_links(mock_ocds_package)
+        self.assertEqual(links, ["ocds-link-001", "ocds-link-002"])
+
+        links_empty = await self.scraper.extract_links({"releases": []})
+        self.assertEqual(links_empty, [])
+        links_no_releases = await self.scraper.extract_links({})
+        self.assertEqual(links_no_releases, [])
+
+    async def test_get_next_page_url_ocds_placeholder(self):
+        """Test placeholder get_next_page_url for OCDS 'links.next'."""
+        mock_ocds_package_with_next = {
+            "links": {"next": "https://mock.api.mendoza.gob.ar/ocds/releases?page=2"}
+        }
+        next_url = await self.scraper.get_next_page_url(mock_ocds_package_with_next, self.config.url)
+        self.assertEqual(next_url, "https://mock.api.mendoza.gob.ar/ocds/releases?page=2")
+
+    async def test_get_next_page_url_api_fallback_placeholder(self):
+        """Test placeholder get_next_page_url for generic API pagination fallback."""
+        mock_api_response_generic_pagination = {
+            "pagination": {"next_page_url_api": "https://other.api.mendoza.gob.ar?offset=10"}
+        }
+        next_url = await self.scraper.get_next_page_url(mock_api_response_generic_pagination, self.config.url)
+        self.assertEqual(next_url, "https://other.api.mendoza.gob.ar?offset=10")
+        
+        mock_api_no_next = {"some_data": "value"}
+        next_url_none = await self.scraper.get_next_page_url(mock_api_no_next, self.config.url)
+        self.assertIsNone(next_url_none)
+
+if __name__ == '__main__':
+    unittest.main()
+```

--- a/tests/scrapers/test_santa_fe_provincia_scraper.py
+++ b/tests/scrapers/test_santa_fe_provincia_scraper.py
@@ -1,0 +1,152 @@
+import unittest
+import asyncio
+from datetime import datetime, timezone
+from typing import Optional, List, Any
+
+from pydantic import HttpUrl
+
+from backend.models.scraper_config import ScraperConfig
+from backend.models.licitacion import LicitacionCreate
+from backend.scrapers.santa_fe_provincia_scraper import SantaFeProvinciaScraper
+
+
+class TestSantaFeProvinciaScraper(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        """Set up test environment for SantaFeProvinciaScraper."""
+        self.config = ScraperConfig(
+            name="Santa Fe Provincia Test",
+            url="https://mock.api.santafe.gob.ar/licitaciones", # Placeholder API URL
+            frequency_seconds=3600,
+            module_path="backend.scrapers.santa_fe_provincia_scraper",
+            enabled=True,
+            headers={"User-Agent": "Test Scraper SantaFe"},
+        )
+        # Assuming SantaFeProvinciaScraper's __init__ is updated to accept config
+        self.scraper = SantaFeProvinciaScraper(self.config)
+        # self.scraper.base_api_url = self.config.url # Potentially set if scraper uses it
+
+    async def test_extract_licitacion_data_api_success(self):
+        """Test successful data extraction from a mock API response."""
+        mock_api_response = {
+            "id_api": "SF_LIC_2023_001",
+            "titulo_api": "Adquisicion de Insumos Hospitalarios",
+            "organismo_api": "Ministerio de Salud Provincial",
+            # "jurisdiccion_api" is not in scraper's direct extraction, defaults to "Santa Fe Provincia"
+            "fecha_publicacion_api": "2023-10-20T11:00:00Z", # ISO format with Z
+            "numero_expediente_api": "EXP-SF-00123-2023",
+            "objeto_licitacion_api": "Compra de materiales descartables y medicamentos.",
+            "estado_api": "En Curso",
+            "monto_oficial_api": "3500750.25", # String, to be converted to float
+            "tipo_contratacion_api": "Licitación Pública",
+            "lugar_entrega_api": "Hospital J.B. Iturraspe, Santa Fe Capital", # Maps to municipios_cubiertos
+        }
+        mock_url = "https://mock.api.santafe.gob.ar/licitaciones/SF_LIC_2023_001"
+
+        licitacion = await self.scraper.extract_licitacion_data(mock_api_response, mock_url)
+
+        self.assertIsNotNone(licitacion)
+        self.assertIsInstance(licitacion, LicitacionCreate)
+
+        self.assertEqual(licitacion.id_licitacion, "SF_LIC_2023_001")
+        self.assertEqual(licitacion.title, "Adquisicion de Insumos Hospitalarios")
+        self.assertEqual(licitacion.organization, "Ministerio de Salud Provincial")
+        self.assertEqual(licitacion.jurisdiccion, "Santa Fe Provincia") # Defaulted by scraper
+        
+        # Updated expected_publication_date to be timezone-aware (UTC)
+        expected_publication_date = datetime(2023, 10, 20, 11, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(licitacion.publication_date, expected_publication_date)
+        
+        self.assertEqual(licitacion.licitacion_number, "EXP-SF-00123-2023")
+        self.assertEqual(licitacion.description, "Compra de materiales descartables y medicamentos.")
+        self.assertEqual(licitacion.status, "En Curso")
+        self.assertEqual(licitacion.budget, 3500750.25)
+        self.assertEqual(licitacion.source_url, HttpUrl(mock_url))
+        self.assertEqual(licitacion.tipo_procedimiento, "Licitación Pública")
+        self.assertEqual(licitacion.tipo_acceso, "API provincial") # Hardcoded by scraper
+        self.assertEqual(licitacion.municipios_cubiertos, "Hospital J.B. Iturraspe, Santa Fe Capital")
+        
+        self.assertIsInstance(licitacion.fecha_scraping, datetime)
+
+    async def test_extract_licitacion_data_api_failure(self):
+        """Test extraction with incomplete/malformed API data."""
+        mock_api_response_incomplete = {
+            "titulo_api": "Licitación Incompleta",
+            # Missing id_api, organismo_api, etc.
+            "monto_oficial_api": "doscientosmil", # Malformed float
+            "fecha_publicacion_api": "ayer", # Malformed date
+        }
+        mock_url = "https://mock.api.santafe.gob.ar/licitaciones/SF_LIC_FAIL_002"
+
+        licitacion = await self.scraper.extract_licitacion_data(mock_api_response_incomplete, mock_url)
+        
+        self.assertIsNotNone(licitacion) # Scraper returns object with defaults
+        self.assertTrue(licitacion.id_licitacion.endswith("_UNKNOWN"))
+        self.assertEqual(licitacion.title, "Licitación Incompleta")
+        self.assertTrue(licitacion.organization.endswith("_UNKNOWN"))
+        self.assertIsNone(licitacion.budget) # "doscientosmil" fails parsing
+        self.assertIsInstance(licitacion.publication_date, datetime) # Defaults to now()
+
+    async def test_extract_licitacion_data_not_dict(self):
+        """Test extraction failure when input data is not a dictionary."""
+        mock_api_response_not_dict = ["esto", "es", "una", "lista"]
+        mock_url = "https://mock.api.santafe.gob.ar/licitaciones/SF_LIC_NOT_DICT"
+        
+        licitacion = await self.scraper.extract_licitacion_data(mock_api_response_not_dict, mock_url)
+        self.assertIsNone(licitacion) # Scraper should return None if data is not dict
+
+    async def test_extract_links_api_placeholder(self):
+        """Test placeholder implementation of extract_links for API data."""
+        # Case 1: API response is a list of items
+        mock_api_list_direct = [
+            {"url_detalle_api": "url1"}, 
+            {"id_api": "item2_no_url"} # Scraper currently only looks for url_detalle_api
+        ]
+        links1 = await self.scraper.extract_links(mock_api_list_direct)
+        self.assertEqual(links1, ["url1"])
+
+        # Case 2: API response is a dict with items under a common key
+        mock_api_dict_with_list = {
+            "data": [{"url_detalle_api": "url_dict_1"}, {"url_detalle_api": "url_dict_2"}],
+            "total": 2
+        }
+        links2 = await self.scraper.extract_links(mock_api_dict_with_list)
+        self.assertEqual(links2, ["url_dict_1", "url_dict_2"])
+        
+        # Case 3: Empty or no relevant data
+        links_empty_list = await self.scraper.extract_links([])
+        self.assertEqual(links_empty_list, [])
+        links_empty_dict = await self.scraper.extract_links({})
+        self.assertEqual(links_empty_dict, [])
+        links_bad_format = await self.scraper.extract_links("not_a_list_or_dict")
+        self.assertEqual(links_bad_format, [])
+
+
+    async def test_get_next_page_url_api_placeholder(self):
+        """Test placeholder implementation of get_next_page_url for API data."""
+        # Case 1: next_page_url_api present
+        mock_api_response_next_url = {
+            "pagination": {"next_page_url_api": "https://mock.api.santafe.gob.ar/licitaciones?page=2"}
+        }
+        next_url1 = await self.scraper.get_next_page_url(mock_api_response_next_url, self.config.url)
+        self.assertEqual(next_url1, "https://mock.api.santafe.gob.ar/licitaciones?page=2")
+
+        # Case 2: nextLink present (alternative key)
+        mock_api_response_next_link = {
+            "paging": {"nextLink": "https://mock.api.santafe.gob.ar/licitaciones?cursor=xyz"}
+        }
+        next_url2 = await self.scraper.get_next_page_url(mock_api_response_next_link, self.config.url)
+        self.assertEqual(next_url2, "https://mock.api.santafe.gob.ar/licitaciones?cursor=xyz")
+
+        # Case 3: No next page info
+        mock_api_response_no_next = {"pagination": {"currentPage": 5, "totalPages": 5}}
+        next_url_none = await self.scraper.get_next_page_url(mock_api_response_no_next, self.config.url)
+        self.assertIsNone(next_url_none)
+        
+        # Case 4: Input not a dict
+        next_url_bad_format = await self.scraper.get_next_page_url("not_a_dict", self.config.url)
+        self.assertIsNone(next_url_bad_format)
+
+if __name__ == '__main__':
+    unittest.main()
+```


### PR DESCRIPTION
Adds placeholder scrapers for five Argentinian provincial procurement data sources:
- Buenos Aires Provincia (API)
- CABA (API/Scraping)
- Córdoba Provincia (Web scraping)
- Santa Fe Provincia (API)
- Mendoza Provincia (API/OCDS)

Key changes:
- Updated `backend/models/licitacion.py` to include new fields in `LicitacionCreate` to accommodate data from these diverse sources. Fields like `id_licitacion`, `jurisdiccion`, `tipo_procedimiento`, `tipo_acceso`, etc., were added.
- Created new scraper files in `backend/scrapers/`:
    - `buenos_aires_provincia_scraper.py`
    - `caba_scraper.py`
    - `cordoba_provincia_scraper.py`
    - `santa_fe_provincia_scraper.py`
    - `mendoza_provincia_scraper.py`
- Each scraper inherits from `BaseScraper` and implements placeholder methods for `extract_licitacion_data`, `extract_links`, and `get_next_page_url`. These methods include logging to indicate that actual API details or HTML selectors are needed.
- Updated `backend/scrapers/scraper_factory.py` to recognize and instantiate these new scrapers based on URL or configuration name.
- Added corresponding unit tests in `tests/scrapers/` for each new scraper. These tests verify the current placeholder logic and provide a framework for future development.

This commit lays the groundwork for integrating these new data sources. Further work will be required to implement the specific parsing logic for each source once API documentation or HTML structures are analyzed in detail.