### PR TITLE
fix: Resolver URLs COMPR.AR expiradas + filtros dinamicos frontend

### DIFF
--- a/tests/scrapers/test_buenos_aires_provincia_scraper.py
+++ b/tests/scrapers/test_buenos_aires_provincia_scraper.py
@@ -161,4 +161,3 @@ class TestBuenosAiresProvinciaScraper(unittest.IsolatedAsyncioTestCase):
 
 if __name__ == '__main__':
     unittest.main()
-```

--- a/tests/scrapers/test_caba_scraper.py
+++ b/tests/scrapers/test_caba_scraper.py
@@ -141,4 +141,3 @@ class TestCabaScraper(unittest.IsolatedAsyncioTestCase):
 
 if __name__ == '__main__':
     unittest.main()
-```

--- a/tests/scrapers/test_comprar_mendoza_scraper.py
+++ b/tests/scrapers/test_comprar_mendoza_scraper.py
@@ -535,6 +535,7 @@ class TestComprarFullRun(unittest.IsolatedAsyncioTestCase):
             "business_days_window": 4,
             "use_selenium_pliego": False,
             "max_pages": 1,
+            "disable_date_filter": False,  # Enable date filtering for this test
         })
         scraper = MendozaCompraScraper(config)
 
@@ -545,7 +546,7 @@ class TestComprarFullRun(unittest.IsolatedAsyncioTestCase):
 
             results = await scraper.run()
 
-        # Old dates should be filtered out
+        # Old dates should be filtered out when disable_date_filter=False
         old_ids = [r.id_licitacion for r in results if r.id_licitacion == "OLD-001"]
         self.assertEqual(len(old_ids), 0, "Old-dated processes should be filtered out")
 

--- a/tests/scrapers/test_cordoba_provincia_scraper.py
+++ b/tests/scrapers/test_cordoba_provincia_scraper.py
@@ -163,4 +163,3 @@ class TestCordobaProvinciaScraper(unittest.IsolatedAsyncioTestCase):
 
 if __name__ == '__main__':
     unittest.main()
-```

--- a/tests/scrapers/test_mendoza_provincia_scraper.py
+++ b/tests/scrapers/test_mendoza_provincia_scraper.py
@@ -169,4 +169,3 @@ class TestMendozaProvinciaScraper(unittest.IsolatedAsyncioTestCase):
 
 if __name__ == '__main__':
     unittest.main()
-```

--- a/tests/scrapers/test_santa_fe_provincia_scraper.py
+++ b/tests/scrapers/test_santa_fe_provincia_scraper.py
@@ -149,4 +149,3 @@ class TestSantaFeProvinciaScraper(unittest.IsolatedAsyncioTestCase):
 
 if __name__ == '__main__':
     unittest.main()
-```


### PR DESCRIPTION
Cambios principales:
- COMPR.AR Router: nuevos endpoints estables /resolve/{numero} y /proceso/by-id/{id} que resuelven URLs PLIEGO directas (7d cache)
- Frontend: carga dinamica de opciones de filtro desde API en vez de valores hardcodeados que no coincidian con la BD
- LicitacionDetailPage: prioriza URLs PLIEGO estables sobre URLs de sesion ASP.NET que expiran

Tests:
- Corrige uso de timezone en tests Boletin (Mendoza vs UTC)
- Corrige sintaxis de archivos test scaffold con backticks
- 69 tests pasan para scrapers Mendoza + utilidades de fechas

https://claude.ai/code/session_01CLH33hf5Z3nZTbJ73nBZ2i