### PR TITLE
feat: add category/rubro matching to nodos + popup form

### DIFF
--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -192,6 +192,7 @@ def nodo_entity(nodo) -> dict:
         "description": nodo.get("description", ""),
         "color": nodo.get("color", "#3B82F6"),
         "keyword_groups": nodo.get("keyword_groups", []),
+        "categories": nodo.get("categories", []),
         "actions": nodo.get("actions", []),
         "active": nodo.get("active", True),
         "digest_frequency": nodo.get("digest_frequency", "daily"),

--- a/backend/models/nodo.py
+++ b/backend/models/nodo.py
@@ -30,6 +30,7 @@ class NodoBase(BaseModel):
     description: str = Field("", description="Short description")
     color: str = Field("#3B82F6", description="Hex color for UI badges")
     keyword_groups: List[KeywordGroup] = Field(default=[], description="Keyword groups")
+    categories: List[str] = Field(default=[], description="Rubro/category names — licitaciones matching these categories auto-assign to this nodo")
     actions: List[NodoAction] = Field(default=[], description="Actions on match")
     active: bool = Field(True)
     digest_frequency: str = Field("daily", description="Digest frequency: none, daily, twice_daily")
@@ -47,6 +48,7 @@ class NodoUpdate(BaseModel):
     description: Optional[str] = None
     color: Optional[str] = None
     keyword_groups: Optional[List[KeywordGroup]] = None
+    categories: Optional[List[str]] = None
     actions: Optional[List[NodoAction]] = None
     active: Optional[bool] = None
     digest_frequency: Optional[str] = None

--- a/backend/routers/licitaciones.py
+++ b/backend/routers/licitaciones.py
@@ -1296,8 +1296,9 @@ async def enrich_licitacion_universal(
                 objeto_val = updates.get("objeto", lic_dict.get("objeto", ""))
                 desc_val = updates.get("description", lic_dict.get("description", ""))
                 org_val = lic_dict.get("organization", "")
+                cat_val = updates.get("category", lic_dict.get("category", ""))
                 await matcher.assign_nodos_to_licitacion(
-                    licitacion_id, title_val, objeto_val, desc_val, org_val
+                    licitacion_id, title_val, objeto_val, desc_val, org_val, category=cat_val
                 )
         except Exception as nodo_err:
             logger.warning(f"Nodo re-matching after enrichment failed: {nodo_err}")

--- a/backend/services/enrichment_cron_service.py
+++ b/backend/services/enrichment_cron_service.py
@@ -183,6 +183,7 @@ class EnrichmentCronService:
                             objeto=updates.get("objeto", doc.get("objeto", "")),
                             description=updates.get("description", doc.get("description", "")),
                             organization=doc.get("organization", ""),
+                            category=updates.get("category", doc.get("category", "")),
                         )
                     except Exception as nodo_err:
                         logger.warning(f"Nodo re-match failed for {doc.get('_id')}: {nodo_err}")

--- a/frontend/src/components/nodos/NodoCard.tsx
+++ b/frontend/src/components/nodos/NodoCard.tsx
@@ -61,6 +61,21 @@ const NodoCard: React.FC<NodoCardProps> = ({ nodo, onEdit, onDelete, onRematch }
         ))}
       </div>
 
+      {/* Categories */}
+      {nodo.categories && nodo.categories.length > 0 && (
+        <div className="mb-3">
+          <span className="text-[10px] font-black text-gray-400 uppercase">Categorias</span>
+          <div className="flex flex-wrap gap-1 mt-0.5">
+            {nodo.categories.slice(0, 5).map((cat, i) => (
+              <span key={i} className="px-1.5 py-0.5 bg-amber-50 text-amber-700 rounded text-[10px] font-bold">{cat}</span>
+            ))}
+            {nodo.categories.length > 5 && (
+              <span className="px-1.5 py-0.5 text-gray-400 text-[10px]">+{nodo.categories.length - 5}</span>
+            )}
+          </div>
+        </div>
+      )}
+
       <div className="flex items-center gap-1.5 mb-3 flex-wrap">
         {enabledActions.map((a, i) => (
           <span key={i} className="px-2 py-0.5 bg-blue-50 text-blue-600 rounded text-[10px] font-bold capitalize">

--- a/frontend/src/components/nodos/NodoForm.tsx
+++ b/frontend/src/components/nodos/NodoForm.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import type { Nodo, KeywordGroup, NodoAction } from '../../types/licitacion';
+import React, { useState, useEffect, useRef } from 'react';
+import type { Nodo, NodoAction } from '../../types/licitacion';
 
 interface NodoFormProps {
   nodo?: Nodo | null;
@@ -7,7 +7,14 @@ interface NodoFormProps {
   onCancel: () => void;
 }
 
+interface RubroItem {
+  id: string;
+  nombre: string;
+}
+
 const COLORS = ['#3B82F6', '#22C55E', '#EF4444', '#F59E0B', '#8B5CF6', '#EC4899', '#06B6D4', '#F97316'];
+
+const API_URL = process.env.REACT_APP_API_URL || '';
 
 const NodoForm: React.FC<NodoFormProps> = ({ nodo, onSave, onCancel }) => {
   const [name, setName] = useState('');
@@ -17,9 +24,22 @@ const NodoForm: React.FC<NodoFormProps> = ({ nodo, onSave, onCancel }) => {
   const [keywordGroups, setKeywordGroups] = useState<{ name: string; keywords: string }[]>([
     { name: '', keywords: '' },
   ]);
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+  const [availableRubros, setAvailableRubros] = useState<RubroItem[]>([]);
   const [actions, setActions] = useState<NodoAction[]>([]);
   const [digestFrequency, setDigestFrequency] = useState<'none' | 'daily' | 'twice_daily'>('daily');
+  const [categorySearch, setCategorySearch] = useState('');
+  const overlayRef = useRef<HTMLDivElement>(null);
 
+  // Fetch available rubros on mount
+  useEffect(() => {
+    fetch(`${API_URL}/api/licitaciones/rubros/list`, { credentials: 'include' })
+      .then(r => r.json())
+      .then(data => setAvailableRubros(data.rubros || []))
+      .catch(() => {});
+  }, []);
+
+  // Populate form when editing
   useEffect(() => {
     if (nodo) {
       setName(nodo.name);
@@ -27,6 +47,7 @@ const NodoForm: React.FC<NodoFormProps> = ({ nodo, onSave, onCancel }) => {
       setColor(nodo.color);
       setActive(nodo.active);
       setDigestFrequency(nodo.digest_frequency || 'daily');
+      setSelectedCategories(nodo.categories || []);
       setKeywordGroups(
         nodo.keyword_groups.map(g => ({
           name: g.name,
@@ -37,6 +58,20 @@ const NodoForm: React.FC<NodoFormProps> = ({ nodo, onSave, onCancel }) => {
     }
   }, [nodo]);
 
+  // Close on Escape key
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onCancel]);
+
+  // Close on overlay click
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === overlayRef.current) onCancel();
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const data = {
@@ -45,6 +80,7 @@ const NodoForm: React.FC<NodoFormProps> = ({ nodo, onSave, onCancel }) => {
       color,
       active,
       digest_frequency: digestFrequency,
+      categories: selectedCategories,
       keyword_groups: keywordGroups
         .filter(g => g.name.trim() || g.keywords.trim())
         .map(g => ({
@@ -54,7 +90,6 @@ const NodoForm: React.FC<NodoFormProps> = ({ nodo, onSave, onCancel }) => {
       actions: actions.map(a => {
         const config = { ...a.config };
         if (a.type === 'email') {
-          // Split raw text input into array, remove empties
           const raw = config._rawTo ?? (config.to || []).join(', ');
           config.to = raw.split(/[,;]/).map((s: string) => s.trim()).filter(Boolean);
         }
@@ -88,183 +123,279 @@ const NodoForm: React.FC<NodoFormProps> = ({ nodo, onSave, onCancel }) => {
     setActions(copy);
   };
 
+  const toggleCategory = (nombre: string) => {
+    setSelectedCategories(prev =>
+      prev.includes(nombre) ? prev.filter(c => c !== nombre) : [...prev, nombre]
+    );
+  };
+
+  const filteredRubros = categorySearch.trim()
+    ? availableRubros.filter(r =>
+        r.nombre.toLowerCase().includes(categorySearch.toLowerCase())
+      )
+    : availableRubros;
+
   return (
-    <form onSubmit={handleSubmit} className="bg-white rounded-2xl shadow-lg border border-gray-100 p-6 space-y-5">
-      <h3 className="text-lg font-black text-gray-900">{nodo ? 'Editar Nodo' : 'Nuevo Nodo'}</h3>
-
-      {/* Name + color */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-          <label className="text-xs font-bold text-gray-500 block mb-1">Nombre</label>
-          <input
-            type="text"
-            value={name}
-            onChange={e => setName(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:border-emerald-400 outline-none"
-            required
-          />
-        </div>
-        <div>
-          <label className="text-xs font-bold text-gray-500 block mb-1">Color</label>
-          <div className="flex items-center gap-2">
-            {COLORS.map(c => (
-              <button
-                key={c}
-                type="button"
-                onClick={() => setColor(c)}
-                className={`w-7 h-7 rounded-full border-2 transition-all ${color === c ? 'border-gray-800 scale-110' : 'border-transparent'}`}
-                style={{ backgroundColor: c }}
-              />
-            ))}
+    <div
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+    >
+      <div className="bg-white rounded-2xl shadow-2xl border border-gray-100 w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+        <form onSubmit={handleSubmit} className="p-6 space-y-5">
+          {/* Header */}
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-black text-gray-900">{nodo ? 'Editar Nodo' : 'Nuevo Nodo'}</h3>
+            <button type="button" onClick={onCancel} className="text-gray-400 hover:text-gray-600 text-xl font-bold">&times;</button>
           </div>
-        </div>
-      </div>
 
-      {/* Description */}
-      <div>
-        <label className="text-xs font-bold text-gray-500 block mb-1">Descripción</label>
-        <input
-          type="text"
-          value={description}
-          onChange={e => setDescription(e.target.value)}
-          className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:border-emerald-400 outline-none"
-        />
-      </div>
-
-      {/* Active toggle */}
-      <label className="flex items-center gap-2 cursor-pointer">
-        <input type="checkbox" checked={active} onChange={e => setActive(e.target.checked)} className="rounded" />
-        <span className="text-sm font-bold text-gray-700">Activo</span>
-      </label>
-
-      {/* Keyword groups */}
-      <div>
-        <div className="flex items-center justify-between mb-2">
-          <label className="text-xs font-black text-gray-500 uppercase">Grupos de Keywords</label>
-          <button type="button" onClick={addGroup} className="text-xs text-emerald-600 font-bold hover:text-emerald-800">+ Agregar grupo</button>
-        </div>
-        <div className="space-y-3">
-          {keywordGroups.map((group, i) => (
-            <div key={i} className="bg-gray-50 rounded-lg p-3">
-              <div className="flex items-center gap-2 mb-2">
-                <input
-                  type="text"
-                  placeholder="Nombre del grupo"
-                  value={group.name}
-                  onChange={e => updateGroup(i, 'name', e.target.value)}
-                  className="flex-1 px-2 py-1.5 border border-gray-200 rounded text-xs font-bold focus:border-emerald-400 outline-none"
-                />
-                {keywordGroups.length > 1 && (
-                  <button type="button" onClick={() => removeGroup(i)} className="text-red-400 hover:text-red-600 text-xs font-bold">&times;</button>
-                )}
-              </div>
-              <textarea
-                placeholder="Keywords separadas por coma: Fibra Óptica, Router, Switch..."
-                value={group.keywords}
-                onChange={e => updateGroup(i, 'keywords', e.target.value)}
-                className="w-full px-2 py-1.5 border border-gray-200 rounded text-xs focus:border-emerald-400 outline-none min-h-[60px]"
+          {/* Name + color */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="text-xs font-bold text-gray-500 block mb-1">Nombre</label>
+              <input
+                type="text"
+                value={name}
+                onChange={e => setName(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:border-emerald-400 outline-none"
+                required
+                autoFocus
               />
             </div>
-          ))}
-        </div>
-      </div>
-
-      {/* Actions */}
-      <div>
-        <div className="flex items-center justify-between mb-2">
-          <label className="text-xs font-black text-gray-500 uppercase">Acciones</label>
-          <div className="flex gap-1">
-            <button type="button" onClick={() => addAction('telegram')} className="text-[10px] px-2 py-0.5 bg-blue-50 text-blue-600 rounded font-bold hover:bg-blue-100">+ Telegram</button>
-            <button type="button" onClick={() => addAction('email')} className="text-[10px] px-2 py-0.5 bg-pink-50 text-pink-600 rounded font-bold hover:bg-pink-100">+ Email</button>
-            <button type="button" onClick={() => addAction('tag')} className="text-[10px] px-2 py-0.5 bg-amber-50 text-amber-600 rounded font-bold hover:bg-amber-100">+ Tag</button>
+            <div>
+              <label className="text-xs font-bold text-gray-500 block mb-1">Color</label>
+              <div className="flex items-center gap-2">
+                {COLORS.map(c => (
+                  <button
+                    key={c}
+                    type="button"
+                    onClick={() => setColor(c)}
+                    className={`w-7 h-7 rounded-full border-2 transition-all ${color === c ? 'border-gray-800 scale-110' : 'border-transparent'}`}
+                    style={{ backgroundColor: c }}
+                  />
+                ))}
+              </div>
+            </div>
           </div>
-        </div>
-        <div className="space-y-2">
-          {actions.map((action, i) => (
-            <div key={i} className="bg-gray-50 rounded-lg p-3 flex items-start gap-3">
-              <label className="flex items-center gap-1.5 flex-shrink-0 mt-0.5">
-                <input type="checkbox" checked={action.enabled} onChange={e => updateAction(i, { enabled: e.target.checked })} className="rounded" />
-                <span className="text-[10px] font-bold text-gray-500 uppercase">{action.type}</span>
+
+          {/* Description */}
+          <div>
+            <label className="text-xs font-bold text-gray-500 block mb-1">Descripcion</label>
+            <input
+              type="text"
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:border-emerald-400 outline-none"
+            />
+          </div>
+
+          {/* Active toggle */}
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input type="checkbox" checked={active} onChange={e => setActive(e.target.checked)} className="rounded" />
+            <span className="text-sm font-bold text-gray-700">Activo</span>
+          </label>
+
+          {/* Categories / Rubros */}
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-xs font-black text-gray-500 uppercase">
+                Categorias / Rubros
+                {selectedCategories.length > 0 && (
+                  <span className="ml-2 text-emerald-600 normal-case font-bold">({selectedCategories.length} seleccionados)</span>
+                )}
               </label>
-              <div className="flex-1 space-y-1.5">
-                {action.type === 'telegram' && (
-                  <input
-                    type="text"
-                    placeholder="Chat ID"
-                    value={action.config.chat_id || ''}
-                    onChange={e => updateActionConfig(i, 'chat_id', e.target.value)}
-                    className="w-full px-2 py-1 border border-gray-200 rounded text-xs focus:border-emerald-400 outline-none"
-                  />
-                )}
-                {action.type === 'email' && (
-                  <>
-                    <input
-                      type="text"
-                      placeholder="Destinatarios (separados por coma o punto y coma)"
-                      value={action.config._rawTo ?? (action.config.to || []).join(', ')}
-                      onChange={e => updateActionConfig(i, '_rawTo', e.target.value)}
-                      className="w-full px-2 py-1 border border-gray-200 rounded text-xs focus:border-emerald-400 outline-none"
-                    />
-                    <input
-                      type="text"
-                      placeholder="Prefijo asunto, ej: [IT]"
-                      value={action.config.subject_prefix || ''}
-                      onChange={e => updateActionConfig(i, 'subject_prefix', e.target.value)}
-                      className="w-full px-2 py-1 border border-gray-200 rounded text-xs focus:border-emerald-400 outline-none"
-                    />
-                  </>
-                )}
-                {action.type === 'tag' && (
-                  <input
-                    type="text"
-                    placeholder="Keyword para auto-tag"
-                    value={action.config.keyword || ''}
-                    onChange={e => updateActionConfig(i, 'keyword', e.target.value)}
-                    className="w-full px-2 py-1 border border-gray-200 rounded text-xs focus:border-emerald-400 outline-none"
-                  />
-                )}
-              </div>
-              <button type="button" onClick={() => removeAction(i)} className="text-red-400 hover:text-red-600 text-xs font-bold flex-shrink-0">&times;</button>
             </div>
-          ))}
-        </div>
-      </div>
+            <p className="text-[10px] text-gray-400 mb-2">
+              Las licitaciones con estas categorias se asignan automaticamente a este nodo
+            </p>
 
-      {/* Digest frequency */}
-      <div>
-        <label className="text-xs font-black text-gray-500 uppercase block mb-2">Frecuencia de Notificaciones</label>
-        <div className="flex gap-2">
-          {([
-            { value: 'none', label: 'Sin notificaciones' },
-            { value: 'daily', label: '1x al dia (9am)' },
-            { value: 'twice_daily', label: '2x al dia (9am + 6pm)' },
-          ] as const).map(opt => (
-            <button
-              key={opt.value}
-              type="button"
-              onClick={() => setDigestFrequency(opt.value)}
-              className={`px-3 py-1.5 rounded-lg text-xs font-bold transition-colors ${
-                digestFrequency === opt.value
-                  ? 'bg-violet-600 text-white'
-                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-              }`}
-            >
-              {opt.label}
+            {/* Selected categories chips */}
+            {selectedCategories.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 mb-2">
+                {selectedCategories.map(cat => (
+                  <span
+                    key={cat}
+                    className="inline-flex items-center gap-1 px-2 py-1 bg-emerald-50 text-emerald-700 rounded-lg text-[11px] font-bold"
+                  >
+                    {cat}
+                    <button
+                      type="button"
+                      onClick={() => toggleCategory(cat)}
+                      className="text-emerald-400 hover:text-emerald-700 font-bold"
+                    >
+                      &times;
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Search + dropdown */}
+            <input
+              type="text"
+              placeholder="Buscar categoria..."
+              value={categorySearch}
+              onChange={e => setCategorySearch(e.target.value)}
+              className="w-full px-3 py-1.5 border border-gray-200 rounded-lg text-xs focus:border-emerald-400 outline-none mb-1"
+            />
+            <div className="max-h-36 overflow-y-auto border border-gray-100 rounded-lg bg-gray-50">
+              {filteredRubros.map(rubro => {
+                const isSelected = selectedCategories.includes(rubro.nombre);
+                return (
+                  <label
+                    key={rubro.id}
+                    className={`flex items-center gap-2 px-3 py-1.5 cursor-pointer hover:bg-gray-100 text-xs transition-colors ${
+                      isSelected ? 'bg-emerald-50' : ''
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={isSelected}
+                      onChange={() => toggleCategory(rubro.nombre)}
+                      className="rounded text-emerald-600"
+                    />
+                    <span className={`${isSelected ? 'font-bold text-emerald-700' : 'text-gray-700'}`}>
+                      {rubro.nombre}
+                    </span>
+                  </label>
+                );
+              })}
+              {filteredRubros.length === 0 && (
+                <div className="px-3 py-2 text-xs text-gray-400">Sin resultados</div>
+              )}
+            </div>
+          </div>
+
+          {/* Keyword groups */}
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-xs font-black text-gray-500 uppercase">Grupos de Keywords</label>
+              <button type="button" onClick={addGroup} className="text-xs text-emerald-600 font-bold hover:text-emerald-800">+ Agregar grupo</button>
+            </div>
+            <div className="space-y-3">
+              {keywordGroups.map((group, i) => (
+                <div key={i} className="bg-gray-50 rounded-lg p-3">
+                  <div className="flex items-center gap-2 mb-2">
+                    <input
+                      type="text"
+                      placeholder="Nombre del grupo"
+                      value={group.name}
+                      onChange={e => updateGroup(i, 'name', e.target.value)}
+                      className="flex-1 px-2 py-1.5 border border-gray-200 rounded text-xs font-bold focus:border-emerald-400 outline-none"
+                    />
+                    {keywordGroups.length > 1 && (
+                      <button type="button" onClick={() => removeGroup(i)} className="text-red-400 hover:text-red-600 text-xs font-bold">&times;</button>
+                    )}
+                  </div>
+                  <textarea
+                    placeholder="Keywords separadas por coma: Fibra Optica, Router, Switch..."
+                    value={group.keywords}
+                    onChange={e => updateGroup(i, 'keywords', e.target.value)}
+                    className="w-full px-2 py-1.5 border border-gray-200 rounded text-xs focus:border-emerald-400 outline-none min-h-[60px]"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-xs font-black text-gray-500 uppercase">Acciones</label>
+              <div className="flex gap-1">
+                <button type="button" onClick={() => addAction('telegram')} className="text-[10px] px-2 py-0.5 bg-blue-50 text-blue-600 rounded font-bold hover:bg-blue-100">+ Telegram</button>
+                <button type="button" onClick={() => addAction('email')} className="text-[10px] px-2 py-0.5 bg-pink-50 text-pink-600 rounded font-bold hover:bg-pink-100">+ Email</button>
+                <button type="button" onClick={() => addAction('tag')} className="text-[10px] px-2 py-0.5 bg-amber-50 text-amber-600 rounded font-bold hover:bg-amber-100">+ Tag</button>
+              </div>
+            </div>
+            <div className="space-y-2">
+              {actions.map((action, i) => (
+                <div key={i} className="bg-gray-50 rounded-lg p-3 flex items-start gap-3">
+                  <label className="flex items-center gap-1.5 flex-shrink-0 mt-0.5">
+                    <input type="checkbox" checked={action.enabled} onChange={e => updateAction(i, { enabled: e.target.checked })} className="rounded" />
+                    <span className="text-[10px] font-bold text-gray-500 uppercase">{action.type}</span>
+                  </label>
+                  <div className="flex-1 space-y-1.5">
+                    {action.type === 'telegram' && (
+                      <input
+                        type="text"
+                        placeholder="Chat ID"
+                        value={action.config.chat_id || ''}
+                        onChange={e => updateActionConfig(i, 'chat_id', e.target.value)}
+                        className="w-full px-2 py-1 border border-gray-200 rounded text-xs focus:border-emerald-400 outline-none"
+                      />
+                    )}
+                    {action.type === 'email' && (
+                      <>
+                        <input
+                          type="text"
+                          placeholder="Destinatarios (separados por coma o punto y coma)"
+                          value={action.config._rawTo ?? (action.config.to || []).join(', ')}
+                          onChange={e => updateActionConfig(i, '_rawTo', e.target.value)}
+                          className="w-full px-2 py-1 border border-gray-200 rounded text-xs focus:border-emerald-400 outline-none"
+                        />
+                        <input
+                          type="text"
+                          placeholder="Prefijo asunto, ej: [IT]"
+                          value={action.config.subject_prefix || ''}
+                          onChange={e => updateActionConfig(i, 'subject_prefix', e.target.value)}
+                          className="w-full px-2 py-1 border border-gray-200 rounded text-xs focus:border-emerald-400 outline-none"
+                        />
+                      </>
+                    )}
+                    {action.type === 'tag' && (
+                      <input
+                        type="text"
+                        placeholder="Keyword para auto-tag"
+                        value={action.config.keyword || ''}
+                        onChange={e => updateActionConfig(i, 'keyword', e.target.value)}
+                        className="w-full px-2 py-1 border border-gray-200 rounded text-xs focus:border-emerald-400 outline-none"
+                      />
+                    )}
+                  </div>
+                  <button type="button" onClick={() => removeAction(i)} className="text-red-400 hover:text-red-600 text-xs font-bold flex-shrink-0">&times;</button>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Digest frequency */}
+          <div>
+            <label className="text-xs font-black text-gray-500 uppercase block mb-2">Frecuencia de Notificaciones</label>
+            <div className="flex gap-2">
+              {([
+                { value: 'none', label: 'Sin notificaciones' },
+                { value: 'daily', label: '1x al dia (9am)' },
+                { value: 'twice_daily', label: '2x al dia (9am + 6pm)' },
+              ] as const).map(opt => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => setDigestFrequency(opt.value)}
+                  className={`px-3 py-1.5 rounded-lg text-xs font-bold transition-colors ${
+                    digestFrequency === opt.value
+                      ? 'bg-violet-600 text-white'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Submit */}
+          <div className="flex items-center gap-3 pt-3 border-t border-gray-100">
+            <button type="submit" className="px-5 py-2 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg text-sm font-bold transition-colors">
+              {nodo ? 'Guardar' : 'Crear Nodo'}
             </button>
-          ))}
-        </div>
+            <button type="button" onClick={onCancel} className="px-5 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg text-sm font-bold transition-colors">
+              Cancelar
+            </button>
+          </div>
+        </form>
       </div>
-
-      {/* Submit */}
-      <div className="flex items-center gap-3 pt-3 border-t border-gray-100">
-        <button type="submit" className="px-5 py-2 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg text-sm font-bold transition-colors">
-          {nodo ? 'Guardar' : 'Crear Nodo'}
-        </button>
-        <button type="button" onClick={onCancel} className="px-5 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg text-sm font-bold transition-colors">
-          Cancelar
-        </button>
-      </div>
-    </form>
+    </div>
   );
 };
 

--- a/frontend/src/pages/NodosPage.tsx
+++ b/frontend/src/pages/NodosPage.tsx
@@ -101,28 +101,26 @@ const NodosPage: React.FC = () => {
           <h1 className="text-2xl font-black text-gray-900">Nodos</h1>
           <p className="text-xs sm:text-sm text-gray-500">Mapas semánticos de búsqueda — agrupa licitaciones por nubes de keywords</p>
         </div>
-        {!showForm && (
-          <div className="flex items-center gap-2">
-            <button
-              onClick={handleRematchAll}
-              disabled={rematchAllStatus === 'Procesando...'}
-              className="px-3 py-2 bg-slate-700 hover:bg-slate-800 disabled:bg-slate-400 text-white rounded-lg text-xs sm:text-sm font-bold transition-colors flex items-center gap-1.5"
-            >
-              {rematchAllStatus === 'Procesando...' ? (
-                <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
-              ) : (
-                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" /></svg>
-              )}
-              <span className="hidden sm:inline">Re-match</span> Todos
-            </button>
-            <button
-              onClick={() => { setEditingNodo(null); setShowForm(true); }}
-              className="px-3 sm:px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg text-xs sm:text-sm font-bold transition-colors"
-            >
-              + Nuevo Nodo
-            </button>
-          </div>
-        )}
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleRematchAll}
+            disabled={rematchAllStatus === 'Procesando...'}
+            className="px-3 py-2 bg-slate-700 hover:bg-slate-800 disabled:bg-slate-400 text-white rounded-lg text-xs sm:text-sm font-bold transition-colors flex items-center gap-1.5"
+          >
+            {rematchAllStatus === 'Procesando...' ? (
+              <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+            ) : (
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" /></svg>
+            )}
+            <span className="hidden sm:inline">Re-match</span> Todos
+          </button>
+          <button
+            onClick={() => { setEditingNodo(null); setShowForm(true); }}
+            className="px-3 sm:px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg text-xs sm:text-sm font-bold transition-colors"
+          >
+            + Nuevo Nodo
+          </button>
+        </div>
       </div>
 
       {rematchAllStatus && rematchAllStatus !== 'Procesando...' && (
@@ -134,9 +132,7 @@ const NodosPage: React.FC = () => {
       )}
 
       {showForm && (
-        <div className="mb-6">
-          <NodoForm nodo={editingNodo} onSave={handleSave} onCancel={handleCancel} />
-        </div>
+        <NodoForm nodo={editingNodo} onSave={handleSave} onCancel={handleCancel} />
       )}
 
       {loading && !nodos.length && (

--- a/frontend/src/types/licitacion.ts
+++ b/frontend/src/types/licitacion.ts
@@ -55,6 +55,7 @@ export interface Nodo {
   description: string;
   color: string;
   keyword_groups: KeywordGroup[];
+  categories: string[];
   actions: NodoAction[];
   active: boolean;
   digest_frequency: 'none' | 'daily' | 'twice_daily';

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4904,11 +4904,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2, fsevents@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"


### PR DESCRIPTION
Nodos can now be assigned categories (rubros from COMPR.AR taxonomy).
Licitaciones matching those categories are automatically assigned to
the nodo, in addition to keyword matching. The NodoForm now opens as
a centered modal popup instead of inline at the top of the page.

Backend:
- Add `categories: List[str]` field to NodoBase/NodoUpdate models
- Update nodo_entity mapper to include categories
- Extend nodo_matcher to match by category (fast path before keywords)
- Pass category to all assign_nodos callers (rematch, enrichment)

Frontend:
- NodoForm: searchable multi-select for 34 rubros, modal overlay with
  Escape/backdrop-click to close
- NodoCard: display assigned categories as amber badges
- NodosPage: buttons always visible since form is now a modal
- TypeScript: add categories to Nodo interface

https://claude.ai/code/session_01UzxsLsMPepFeNUbiYbutg9