### PR TITLE
FIX: Enforce opening_date >= today in APERTURAS view

### DIFF
--- a/backend/routers/licitaciones.py
+++ b/backend/routers/licitaciones.py
@@ -199,6 +199,13 @@ async def get_licitaciones(
     if fecha_campo not in allowed_date_fields:
         fecha_campo = "publication_date"
 
+    # When filtering by opening_date, enforce fecha_desde >= today
+    # (aperturas view should never show past opening dates)
+    today = date.today()
+    if fecha_campo == "opening_date":
+        if not fecha_desde or fecha_desde < today:
+            fecha_desde = today
+
     if fecha_desde or fecha_hasta:
         date_filter = {}
         if fecha_desde:

--- a/frontend/src/components/licitaciones/FilterSidebar.tsx
+++ b/frontend/src/components/licitaciones/FilterSidebar.tsx
@@ -454,6 +454,7 @@ const FilterSidebar: React.FC<FilterSidebarProps> = ({
                     className="w-full px-2 py-1.5 bg-gray-50 border border-gray-200 rounded-lg text-xs outline-none focus:border-emerald-400"
                     value={filters.fechaDesde}
                     onChange={(e) => onFilterChange('fechaDesde', e.target.value)}
+                    min={fechaCampo === 'opening_date' ? new Date().toISOString().slice(0, 10) : undefined}
                   />
                 </div>
                 <div>

--- a/frontend/src/components/licitaciones/MobileFilterDrawer.tsx
+++ b/frontend/src/components/licitaciones/MobileFilterDrawer.tsx
@@ -402,6 +402,7 @@ const MobileFilterDrawer: React.FC<MobileFilterDrawerProps> = ({
                       className="w-full px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg text-sm outline-none focus:border-emerald-400"
                       value={filters.fechaDesde}
                       onChange={(e) => onFilterChange('fechaDesde', e.target.value)}
+                      min={fechaCampo === 'opening_date' ? new Date().toISOString().slice(0, 10) : undefined}
                     />
                   </div>
                   <div>


### PR DESCRIPTION
When sorting by opening_date (aperturas view), date filters should never
allow dates before today since past opening dates are irrelevant.

Backend: auto-clamp fecha_desde to today when fecha_campo=opening_date
Frontend: auto-set fechaDesde on sort switch, clamp in handlers, min attr on inputs

https://claude.ai/code/session_012Juj2GmcpHMPGyYLcB78Tk