### PR TITLE
Make licitacion card titles clickable links to detail page

### DIFF
--- a/frontend/src/components/licitaciones/LicitacionCard.tsx
+++ b/frontend/src/components/licitaciones/LicitacionCard.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { Link } from 'react-router-dom';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 import WorkflowBadge from '../WorkflowBadge';
@@ -186,8 +187,14 @@ const LicitacionCard: React.FC<LicitacionCardProps> = ({
               )}
 
               {/* Descriptive title = main heading */}
-              <h3 className="text-base font-black text-gray-900 group-hover:text-blue-700 leading-tight mb-1.5 line-clamp-2">
-                {searchQuery ? highlightMatches(lic.objeto || lic.title, searchQuery) : (lic.objeto || lic.title)}
+              <h3 className="text-base font-black text-gray-900 leading-tight mb-1.5 line-clamp-2">
+                <Link
+                  to={`/licitacion/${lic.id}`}
+                  className="hover:text-blue-700 transition-colors"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {searchQuery ? highlightMatches(lic.objeto || lic.title, searchQuery) : (lic.objeto || lic.title)}
+                </Link>
               </h3>
 
               {/* Organization + meta */}


### PR DESCRIPTION
Wraps the <h3> title in a <Link> so users can right-click to open
in a new tab, middle-click, or copy the URL directly. Uses
stopPropagation to avoid double-navigation from the card's onClick.

https://claude.ai/code/session_01R3r4meJTL8NUbgWSHV28N1