### PR TITLE
feat: auto-seed 10 AR sources on startup + seed button in admin

### DIFF
--- a/backend/routers/licitaciones_ar.py
+++ b/backend/routers/licitaciones_ar.py
@@ -426,6 +426,52 @@ async def get_ar_sources(request: Request):
     return [scraper_config_entity(c) for c in configs]
 
 
+@router.post("/seed-sources")
+async def seed_ar_sources(request: Request):
+    """Seed AR scraper configs from built-in list (idempotent upsert)."""
+    from datetime import datetime
+
+    db = request.app.mongodb
+    collection = db.scraper_configs
+
+    AR_SOURCES = [
+        {"name": "datos_argentina_contrataciones", "url": "https://datos.gob.ar/dataset?tags=Contrataciones", "active": True, "schedule": "0 8,14 * * 1-5", "selectors": {"dataset_id": "jgm-sistema-contrataciones-electronicas", "scraper_type": "datos_argentina"}, "source_type": "api", "max_items": 200, "wait_time": 1.0, "scope": "ar_nacional"},
+        {"name": "datos_argentina_contratar", "url": "https://datos.gob.ar/dataset/jgm-procesos-contratacion-obra-publica-gestionados-plataforma-contratar", "active": True, "schedule": "0 9 * * 1-5", "selectors": {"dataset_id": "jgm-procesos-contratacion-obra-publica-gestionados-plataforma-contratar", "scraper_type": "datos_argentina"}, "source_type": "api", "max_items": 200, "wait_time": 1.0, "scope": "ar_nacional"},
+        {"name": "contrataciones_abiertas_mendoza_ocds", "url": "https://datosabiertos-compras.mendoza.gov.ar/datosabiertos/", "active": True, "schedule": "0 10 * * 1-5", "selectors": {"scraper_type": "contrataciones_abiertas_mza"}, "source_type": "api", "max_items": 200, "wait_time": 1.0, "scope": "ar_nacional"},
+        {"name": "banco_mundial_argentina", "url": "https://search.worldbank.org/api/v2/procnotices", "active": True, "schedule": "0 7 * * 1-5", "selectors": {"scraper_type": "banco_mundial"}, "source_type": "api", "max_items": 100, "wait_time": 2.0, "scope": "ar_nacional"},
+        {"name": "bid_procurement_argentina", "url": "https://data.iadb.org/dataset/project-procurement-bidding-notices-and-notification-of-contract-awards", "active": True, "schedule": "0 7 * * 1-5", "selectors": {"resource_id": "856aabfd-2c6a-48fb-a8b8-19f3ff443618", "scraper_type": "bid"}, "source_type": "api", "max_items": 100, "wait_time": 2.0, "scope": "ar_nacional"},
+        {"name": "santa_fe_compras", "url": "https://www.santafe.gov.ar/index.php/guia/portal_compras", "active": True, "schedule": "0 8,14 * * 1-5", "selectors": {"rss_url": "https://www.santafe.gov.ar/index.php/guia/portal_compras?pagina=rss", "cartelera_url": "https://www.santafe.gov.ar/index.php/guia/portal_compras", "scraper_type": "santa_fe"}, "source_type": "website", "max_items": 100, "wait_time": 2.0, "scope": "ar_nacional"},
+        {"name": "comprar_gob_ar_nacional", "url": "https://comprar.gob.ar/BuscarAvanzado.aspx", "active": True, "schedule": "0 8,12,18 * * 1-5", "selectors": {"title": "h1.titulo", "organization": "div.organismo", "publication_date": "div.fecha-publicacion", "opening_date": "div.fecha-apertura", "links": "table.items a.ver-detalle"}, "source_type": "website", "max_items": 100, "wait_time": 2.0, "scope": "ar_nacional"},
+        {"name": "contratar_gob_ar", "url": "https://contratar.gob.ar/", "active": True, "schedule": "0 9,15 * * 1-5", "selectors": {"scraper_type": "contratar"}, "source_type": "website", "max_items": 100, "wait_time": 3.0, "scope": "ar_nacional"},
+        {"name": "boletin_oficial_nacional", "url": "https://www.boletinoficial.gob.ar/seccion/tercera", "active": True, "schedule": "0 8,13 * * 1-5", "selectors": {"section_url": "https://www.boletinoficial.gob.ar/seccion/tercera", "scraper_type": "boletin_oficial_nacional"}, "source_type": "website", "max_items": 50, "wait_time": 3.0, "scope": "ar_nacional"},
+        {"name": "pbac_buenos_aires", "url": "https://pbac.cgp.gba.gov.ar/", "active": True, "schedule": "0 8,14 * * 1-5", "selectors": {"scraper_type": "pbac"}, "source_type": "website", "max_items": 100, "wait_time": 3.0, "scope": "ar_nacional"},
+    ]
+
+    created = 0
+    updated = 0
+    now = datetime.utcnow()
+
+    for source in AR_SOURCES:
+        existing = await collection.find_one({"name": source["name"]})
+        if existing:
+            await collection.update_one(
+                {"name": source["name"]},
+                {"$set": {**source, "updated_at": now}},
+            )
+            updated += 1
+        else:
+            source["created_at"] = now
+            source["updated_at"] = now
+            source["runs_count"] = 0
+            source["last_run"] = None
+            source["headers"] = {}
+            source["cookies"] = {}
+            await collection.insert_one(source)
+            created += 1
+
+    return {"created": created, "updated": updated, "total": len(AR_SOURCES)}
+
+
 @router.post("/trigger-all")
 async def trigger_all_ar_scrapers(request: Request):
     """Trigger all active AR scrapers sequentially."""

--- a/backend/server.py
+++ b/backend/server.py
@@ -155,6 +155,33 @@ async def startup_db_client():
     except Exception as e:
         logger.error(f"Failed to seed admin user: {e}")
 
+    # Auto-seed AR national sources if none exist
+    try:
+        ar_count = await database.scraper_configs.count_documents({"scope": "ar_nacional"})
+        if ar_count == 0:
+            from datetime import datetime as dt_seed
+            AR_SOURCES = [
+                {"name": "datos_argentina_contrataciones", "url": "https://datos.gob.ar/dataset?tags=Contrataciones", "active": True, "schedule": "0 8,14 * * 1-5", "selectors": {"dataset_id": "jgm-sistema-contrataciones-electronicas", "scraper_type": "datos_argentina"}, "source_type": "api", "max_items": 200, "wait_time": 1.0, "scope": "ar_nacional"},
+                {"name": "datos_argentina_contratar", "url": "https://datos.gob.ar/dataset/jgm-procesos-contratacion-obra-publica-gestionados-plataforma-contratar", "active": True, "schedule": "0 9 * * 1-5", "selectors": {"dataset_id": "jgm-procesos-contratacion-obra-publica-gestionados-plataforma-contratar", "scraper_type": "datos_argentina"}, "source_type": "api", "max_items": 200, "wait_time": 1.0, "scope": "ar_nacional"},
+                {"name": "contrataciones_abiertas_mendoza_ocds", "url": "https://datosabiertos-compras.mendoza.gov.ar/datosabiertos/", "active": True, "schedule": "0 10 * * 1-5", "selectors": {"scraper_type": "contrataciones_abiertas_mza"}, "source_type": "api", "max_items": 200, "wait_time": 1.0, "scope": "ar_nacional"},
+                {"name": "banco_mundial_argentina", "url": "https://search.worldbank.org/api/v2/procnotices", "active": True, "schedule": "0 7 * * 1-5", "selectors": {"scraper_type": "banco_mundial"}, "source_type": "api", "max_items": 100, "wait_time": 2.0, "scope": "ar_nacional"},
+                {"name": "bid_procurement_argentina", "url": "https://data.iadb.org/dataset/project-procurement-bidding-notices-and-notification-of-contract-awards", "active": True, "schedule": "0 7 * * 1-5", "selectors": {"resource_id": "856aabfd-2c6a-48fb-a8b8-19f3ff443618", "scraper_type": "bid"}, "source_type": "api", "max_items": 100, "wait_time": 2.0, "scope": "ar_nacional"},
+                {"name": "santa_fe_compras", "url": "https://www.santafe.gov.ar/index.php/guia/portal_compras", "active": True, "schedule": "0 8,14 * * 1-5", "selectors": {"rss_url": "https://www.santafe.gov.ar/index.php/guia/portal_compras?pagina=rss", "cartelera_url": "https://www.santafe.gov.ar/index.php/guia/portal_compras", "scraper_type": "santa_fe"}, "source_type": "website", "max_items": 100, "wait_time": 2.0, "scope": "ar_nacional"},
+                {"name": "comprar_gob_ar_nacional", "url": "https://comprar.gob.ar/BuscarAvanzado.aspx", "active": True, "schedule": "0 8,12,18 * * 1-5", "selectors": {"title": "h1.titulo", "organization": "div.organismo", "publication_date": "div.fecha-publicacion", "opening_date": "div.fecha-apertura", "links": "table.items a.ver-detalle"}, "source_type": "website", "max_items": 100, "wait_time": 2.0, "scope": "ar_nacional"},
+                {"name": "contratar_gob_ar", "url": "https://contratar.gob.ar/", "active": True, "schedule": "0 9,15 * * 1-5", "selectors": {"scraper_type": "contratar"}, "source_type": "website", "max_items": 100, "wait_time": 3.0, "scope": "ar_nacional"},
+                {"name": "boletin_oficial_nacional", "url": "https://www.boletinoficial.gob.ar/seccion/tercera", "active": True, "schedule": "0 8,13 * * 1-5", "selectors": {"section_url": "https://www.boletinoficial.gob.ar/seccion/tercera", "scraper_type": "boletin_oficial_nacional"}, "source_type": "website", "max_items": 50, "wait_time": 3.0, "scope": "ar_nacional"},
+                {"name": "pbac_buenos_aires", "url": "https://pbac.cgp.gba.gov.ar/", "active": True, "schedule": "0 8,14 * * 1-5", "selectors": {"scraper_type": "pbac"}, "source_type": "website", "max_items": 100, "wait_time": 3.0, "scope": "ar_nacional"},
+            ]
+            now = dt_seed.utcnow()
+            for src in AR_SOURCES:
+                src.update({"created_at": now, "updated_at": now, "runs_count": 0, "last_run": None, "headers": {}, "cookies": {}})
+            await database.scraper_configs.insert_many(AR_SOURCES)
+            logger.info(f"Auto-seeded {len(AR_SOURCES)} AR national scraper configs")
+        else:
+            logger.info(f"AR scraper configs already exist ({ar_count}), skipping auto-seed")
+    except Exception as e:
+        logger.error(f"Failed to auto-seed AR sources: {e}")
+
     # Ensure indexes are created
     try:
         from db.repositories import LicitacionRepository, ScraperConfigRepository

--- a/frontend/src/components/admin/AdminARPanel.tsx
+++ b/frontend/src/components/admin/AdminARPanel.tsx
@@ -83,6 +83,21 @@ const AdminARPanel = () => {
     }
   };
 
+  const handleSeedSources = async () => {
+    setActionLoading('seed');
+    setDigestResult(null);
+    try {
+      const res = await axios.post(`${API_BASE}/seed-sources`);
+      setDigestResult(`Fuentes creadas: ${res.data.created}, actualizadas: ${res.data.updated} (total: ${res.data.total})`);
+      await fetchSources();
+      await fetchStats();
+    } catch (err) {
+      setDigestResult('Error al crear fuentes AR');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
   const handleBatchNodos = async () => {
     setActionLoading('nodos');
     setNodoResult(null);
@@ -252,8 +267,15 @@ const AdminARPanel = () => {
               ))}
               {sources.length === 0 && (
                 <tr>
-                  <td colSpan={5} className="px-4 py-8 text-center text-gray-400">
-                    No hay fuentes AR configuradas. Ejecuta <code>seed_ar_sources.py</code> para crearlas.
+                  <td colSpan={5} className="px-4 py-8 text-center">
+                    <p className="text-gray-400 mb-3">No hay fuentes AR configuradas.</p>
+                    <button
+                      onClick={handleSeedSources}
+                      disabled={actionLoading === 'seed'}
+                      className="px-4 py-2 bg-sky-600 text-white rounded-lg text-sm font-medium hover:bg-sky-700 disabled:opacity-50"
+                    >
+                      {actionLoading === 'seed' ? 'Creando fuentes...' : 'Crear 10 Fuentes AR'}
+                    </button>
                   </td>
                 </tr>
               )}


### PR DESCRIPTION
- server.py: auto-seeds 10 AR scraper configs on startup if none exist
- POST /api/licitaciones-ar/seed-sources: manual seed endpoint
- AdminARPanel: "Crear 10 Fuentes AR" button when table is empty

https://claude.ai/code/session_01VssmR9VX1xRTZjTHNsuDSj