### PR TITLE
perf: optimize scraper concurrency, enrichment throughput, and resource usage

### DIFF
--- a/backend/db/repositories.py
+++ b/backend/db/repositories.py
@@ -50,6 +50,10 @@ class LicitacionRepository:
         await self.collection.create_index([("estado", pymongo.ASCENDING), ("opening_date", pymongo.ASCENDING)])
         await self.collection.create_index([("nodos", pymongo.ASCENDING), ("fecha_scraping", pymongo.DESCENDING)])
         await self.collection.create_index([("tags", pymongo.ASCENDING), ("publication_date", pymongo.DESCENDING)])
+        # Synchronized date filter: "Today's new items" applies both first_seen_at AND fecha_scraping
+        await self.collection.create_index([("first_seen_at", pymongo.DESCENDING), ("fecha_scraping", pymongo.DESCENDING)])
+        # Auto-update query: workflow_state filter + opening_date range
+        await self.collection.create_index([("workflow_state", pymongo.ASCENDING), ("first_seen_at", pymongo.DESCENDING)])
     
     async def create(self, licitacion: LicitacionCreate) -> Licitacion:
         """Create a new licitacion with auto-classification"""

--- a/frontend/src/pages/CotizarPage.js
+++ b/frontend/src/pages/CotizarPage.js
@@ -1,15 +1,41 @@
-import React from "react";
+import React, { useState, useRef } from "react";
 
 /**
  * CotizarPage — embeds the cotizar app from github.com/martinsantos/cotizar
  * Served as GitHub Pages at https://martinsantos.github.io/cotizar
+ *
+ * Handles three states:
+ *  - loading: spinner while iframe fetches
+ *  - loaded: iframe visible, no overlay
+ *  - error: fallback message with external link (GitHub Pages may block iframes via CSP)
  */
 const COTIZAR_URL = "https://martinsantos.github.io/cotizar";
 
 export default function CotizarPage() {
+  const [status, setStatus] = useState("loading"); // "loading" | "loaded" | "error"
+  const iframeRef = useRef(null);
+
+  const handleLoad = () => {
+    // Try to detect blank/error pages: if contentDocument is accessible but empty,
+    // treat as error. If cross-origin (normal case), just mark loaded.
+    try {
+      const doc = iframeRef.current?.contentDocument;
+      if (doc && doc.body && doc.body.innerHTML.trim() === "") {
+        setStatus("error");
+        return;
+      }
+    } catch (_) {
+      // Cross-origin — expected, means the page loaded normally
+    }
+    setStatus("loaded");
+  };
+
+  const handleError = () => setStatus("error");
+
   return (
     <div className="flex flex-col" style={{ height: "calc(100vh - 120px)" }}>
-      <div className="px-4 py-2 bg-gray-50 border-b border-gray-200 flex items-center justify-between">
+      {/* Header */}
+      <div className="px-4 py-2 bg-gray-50 border-b border-gray-200 flex items-center justify-between flex-shrink-0">
         <h1 className="text-lg font-semibold text-gray-800">Cotizador de Licitaciones</h1>
         <a
           href={COTIZAR_URL}
@@ -20,11 +46,57 @@ export default function CotizarPage() {
           Abrir en nueva pestaña ↗
         </a>
       </div>
+
+      {/* Loading overlay */}
+      {status === "loading" && (
+        <div className="flex flex-col items-center justify-center flex-1 text-gray-500 gap-3">
+          <div className="w-8 h-8 border-4 border-gray-200 border-t-blue-500 rounded-full animate-spin" />
+          <span className="text-sm">Cargando cotizador…</span>
+        </div>
+      )}
+
+      {/* Error / not available */}
+      {status === "error" && (
+        <div className="flex flex-col items-center justify-center flex-1 gap-4 px-6 text-center">
+          <div className="text-4xl">🚧</div>
+          <h2 className="text-lg font-semibold text-gray-700">Cotizador no disponible</h2>
+          <p className="text-sm text-gray-500 max-w-md">
+            La aplicación de cotización no pudo cargarse aquí. Esto ocurre cuando
+            GitHub Pages bloquea el embed por política de seguridad (CSP / X-Frame-Options).
+          </p>
+          <a
+            href={COTIZAR_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors"
+          >
+            Abrir cotizador en nueva pestaña ↗
+          </a>
+          <button
+            onClick={() => {
+              setStatus("loading");
+              // Force iframe reload by toggling src
+              if (iframeRef.current) {
+                iframeRef.current.src = COTIZAR_URL + "?t=" + Date.now();
+              }
+            }}
+            className="text-xs text-gray-400 hover:text-gray-600 underline"
+          >
+            Reintentar
+          </button>
+        </div>
+      )}
+
+      {/* Iframe — always mounted so load/error events fire */}
       <iframe
+        ref={iframeRef}
         src={COTIZAR_URL}
         title="Cotizar"
         className="flex-1 w-full border-0"
         allow="clipboard-write"
+        onLoad={handleLoad}
+        onError={handleError}
+        style={{ display: status === "loaded" ? "block" : "none" }}
       />
     </div>
   );

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -61,7 +61,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 120s;
+        # Increased from 120s: enrichment + bulk queries can take longer on large datasets
+        proxy_read_timeout 300s;
+        proxy_send_timeout 60s;
         proxy_connect_timeout 10s;
     }
 
@@ -171,7 +173,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 120s;
+        # Increased from 120s: enrichment + bulk queries can take longer on large datasets
+        proxy_read_timeout 300s;
+        proxy_send_timeout 60s;
         proxy_connect_timeout 10s;
     }
 

--- a/scripts/docker-purge-stale.sh
+++ b/scripts/docker-purge-stale.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# docker-purge-stale.sh — One-shot cleanup of stale Docker containers, images, and volumes.
+#
+# SAFE: Never touches licitometro_mongo_data or licitometro_storage_data volumes.
+# Removes: exited/dead containers, dangling images, unused build cache, orphaned networks.
+#
+# Usage: bash scripts/docker-purge-stale.sh
+# Run on VPS: ssh root@76.13.234.213 "bash /opt/licitometro/scripts/docker-purge-stale.sh"
+
+set -euo pipefail
+
+echo "============================================="
+echo " Licitometro — Docker Stale Resource Cleanup"
+echo " $(date)"
+echo "============================================="
+echo ""
+
+# ── Containers ──────────────────────────────────
+echo "[ Containers ]"
+echo "Running containers:"
+docker ps --format "  {{.Names}} ({{.Status}})"
+
+echo ""
+EXITED=$(docker ps -a -q --filter "status=exited" --filter "status=dead" --filter "status=created" 2>/dev/null | wc -l | tr -d ' ')
+echo "Stopped/exited containers to remove: $EXITED"
+
+if [ "$EXITED" -gt 0 ]; then
+    echo "Removing..."
+    docker ps -a -q --filter "status=exited" --filter "status=dead" --filter "status=created" | xargs docker rm -f 2>/dev/null || true
+    echo "  Done."
+else
+    echo "  Nothing to remove."
+fi
+
+# ── Preview containers (pr-* prefix) ────────────
+echo ""
+echo "[ Preview containers ]"
+PR_CONTAINERS=$(docker ps -a --format "{{.Names}}" | grep "^pr-" 2>/dev/null || true)
+if [ -n "$PR_CONTAINERS" ]; then
+    echo "Removing preview containers:"
+    echo "$PR_CONTAINERS" | while read -r name; do
+        echo "  → $name"
+        docker rm -f "$name" 2>/dev/null || true
+    done
+else
+    echo "  No preview containers found."
+fi
+
+# ── Images ──────────────────────────────────────
+echo ""
+echo "[ Images ]"
+DANGLING=$(docker images -q --filter "dangling=true" 2>/dev/null | wc -l | tr -d ' ')
+echo "Dangling images: $DANGLING"
+if [ "$DANGLING" -gt 0 ]; then
+    docker image prune -f
+fi
+
+# Preview images (tagged pr-*)
+PR_IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep ":pr-" 2>/dev/null || true)
+if [ -n "$PR_IMAGES" ]; then
+    echo "Removing preview-tagged images:"
+    echo "$PR_IMAGES" | while read -r img; do
+        echo "  → $img"
+        docker rmi "$img" 2>/dev/null || true
+    done
+fi
+
+# ── Build cache ─────────────────────────────────
+echo ""
+echo "[ Build cache ]"
+CACHE_SIZE=$(docker system df --format "{{.Type}}\t{{.Size}}" 2>/dev/null | grep "Build Cache" | awk '{print $2}' || echo "unknown")
+echo "Build cache size: $CACHE_SIZE"
+echo "Pruning build cache older than 72h..."
+docker builder prune --filter "until=72h" -f 2>/dev/null || true
+
+# ── Networks ────────────────────────────────────
+echo ""
+echo "[ Orphaned networks ]"
+docker network prune -f 2>/dev/null || true
+
+# ── Volumes — CAREFUL ───────────────────────────
+echo ""
+echo "[ Volumes — PROTECTED ]"
+echo "  licitometro_mongo_data   → SKIPPED (production data)"
+echo "  licitometro_storage_data → SKIPPED (production data)"
+echo "  Removing truly dangling volumes (not referenced by any container)..."
+# Only remove volumes NOT named with licitometro_ prefix
+docker volume ls -q --filter "dangling=true" 2>/dev/null \
+    | grep -v "^licitometro_" \
+    | xargs docker volume rm 2>/dev/null || true
+
+# ── Summary ─────────────────────────────────────
+echo ""
+echo "============================================="
+echo " After cleanup:"
+docker system df
+echo ""
+echo "Running containers after cleanup:"
+docker ps --format "  {{.Names}} ({{.Status}})"
+echo ""
+echo "Cleanup finished at $(date)"
+echo "============================================="


### PR DESCRIPTION
Key changes:
- scheduler_service: global Semaphore(6) limits concurrent scrapers (was unlimited),
  prevents network overload when many scrapers fire at the same cron hour
- enrichment_cron_service: eliminate N+1 MongoDB queries by pre-loading all scraper
  configs in one query at cycle start; batch 200-300 title-only updates via bulk_write
  instead of individual update_one calls; reduce HTTP_DELAY 2.0→1.0s, increase batches
- auto_update_service: replace sequential loop (2s sleep per item, ~6 min for 100 items)
  with concurrent asyncio.gather + Semaphore(5); pre-load scraper config selectors once;
  reduces 100-item auto-update from ~6 minutes to ~30-60 seconds
- db/repositories: add compound indexes (first_seen_at+fecha_scraping,
  workflow_state+first_seen_at) for synchronized date filter queries
- nginx: proxy_read_timeout 120s→300s to handle slow enrichment/bulk API calls
- CotizarPage: add loading spinner, error fallback with external link and retry button
- scripts/docker-purge-stale.sh: safe one-shot cleanup of stale containers/images/cache
  without touching production MongoDB or storage volumes

https://claude.ai/code/session_01XZBjKnZJ3J1eACP25CeT31