### PR TITLE
fix: harden API against 500 errors + fix dual-scheduler + add diagnostics

### DIFF
--- a/backend/routers/licitaciones.py
+++ b/backend/routers/licitaciones.py
@@ -26,7 +26,7 @@ router = APIRouter(
     responses={404: {"description": "Not found"}}
 )
 
-@router.post("/", response_model=Licitacion)
+@router.post("/", response_model=Dict[str, Any])
 async def create_licitacion(
     licitacion: LicitacionCreate,
     repo: LicitacionRepository = Depends(get_licitacion_repository)
@@ -1546,18 +1546,20 @@ async def enrich_licitacion_universal(
         })
 
 
-@router.get("/{licitacion_id}", response_model=Licitacion)
+@router.get("/{licitacion_id}", response_model=Dict[str, Any])
 async def get_licitacion(
     licitacion_id: str,
     repo: LicitacionRepository = Depends(get_licitacion_repository)
 ):
-    """Get a licitacion by id"""
+    """Get a licitacion by id.
+    NOTE: Uses Dict response_model (not Licitacion) to avoid Pydantic validator
+    rejecting documents with dates outside 2024-2027 or opening < publication."""
     licitacion = await repo.get_by_id(licitacion_id)
     if not licitacion:
         raise HTTPException(status_code=404, detail="Licitación not found")
     return licitacion
 
-@router.put("/{licitacion_id}", response_model=Licitacion)
+@router.put("/{licitacion_id}", response_model=Dict[str, Any])
 async def update_licitacion(
     licitacion_id: str,
     licitacion: LicitacionUpdate,

--- a/backend/routers/licitaciones.py
+++ b/backend/routers/licitaciones.py
@@ -5,6 +5,7 @@ from typing import List, Dict, Optional, Any
 from uuid import UUID
 from datetime import date, datetime
 import logging
+import os
 import re
 import sys
 from bson import ObjectId
@@ -83,7 +84,83 @@ async def get_licitaciones(
         )
     except Exception as e:
         logger.error(f"GET /api/licitaciones/ failed: {type(e).__name__}: {e}", exc_info=True)
+        # Also log to dedicated API error file (survives enrichment log flood)
+        _api_err_logger = logging.getLogger("api_errors")
+        _api_err_logger.error(f"GET /api/licitaciones/ failed: {type(e).__name__}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Error interno: {type(e).__name__}: {str(e)[:200]}")
+
+
+@router.get("/debug-query")
+async def debug_query(
+    request: Request,
+    repo: LicitacionRepository = Depends(get_licitacion_repository),
+):
+    """Diagnostic endpoint: test basic query and report errors.
+    Returns DB connection status, sample document, and serialization health."""
+    import traceback
+    from db.models import licitacion_entity
+    results = {"status": "ok", "checks": {}}
+
+    # Check 1: DB connection
+    try:
+        db = request.app.mongodb
+        count = await db.licitaciones.estimated_document_count()
+        results["checks"]["db_connection"] = {"ok": True, "document_count": count}
+    except Exception as e:
+        results["checks"]["db_connection"] = {"ok": False, "error": f"{type(e).__name__}: {e}"}
+        results["status"] = "error"
+
+    # Check 2: Fetch 1 document and serialize it
+    try:
+        doc = await db.licitaciones.find_one()
+        if doc:
+            entity = licitacion_entity(doc)
+            # Test JSON serialization (same as FastAPI would do)
+            encoded = jsonable_encoder(entity)
+            results["checks"]["serialization"] = {
+                "ok": True,
+                "sample_id": entity.get("id", "?"),
+                "sample_title": (entity.get("title", "?"))[:80],
+                "_id_type": type(doc["_id"]).__name__,
+            }
+        else:
+            results["checks"]["serialization"] = {"ok": True, "note": "no documents"}
+    except Exception as e:
+        results["checks"]["serialization"] = {
+            "ok": False,
+            "error": f"{type(e).__name__}: {e}",
+            "traceback": traceback.format_exc()[-500:],
+        }
+        results["status"] = "error"
+
+    # Check 3: Fetch first page (same as GET /api/licitaciones/?page=1&size=1)
+    try:
+        filters = {"tags": {"$ne": "LIC_AR"}}
+        items = await repo.get_all(
+            skip=0, limit=1, filters=filters,
+            sort_by="publication_date", sort_order=-1,
+            projection=repo.LIST_PROJECTION,
+        )
+        total = await repo.count(filters=filters)
+        encoded_items = jsonable_encoder(items)
+        results["checks"]["list_query"] = {
+            "ok": True,
+            "total": total,
+            "returned": len(items),
+            "first_item_id": items[0]["id"] if items else None,
+        }
+    except Exception as e:
+        results["checks"]["list_query"] = {
+            "ok": False,
+            "error": f"{type(e).__name__}: {e}",
+            "traceback": traceback.format_exc()[-500:],
+        }
+        results["status"] = "error"
+
+    # Check 4: Worker info
+    results["worker_pid"] = os.getpid()
+
+    return results
 
 
 async def _get_licitaciones_impl(

--- a/backend/server.py
+++ b/backend/server.py
@@ -27,6 +27,18 @@ logging.basicConfig(
 )
 logger = logging.getLogger("licitometro")
 
+# Dedicated file handler for API errors — survives enrichment log flood.
+# Writes to /app/storage/api_errors.log (Docker volume) or ./api_errors.log (local).
+_api_error_logger = logging.getLogger("api_errors")
+_api_error_logger.setLevel(logging.ERROR)
+try:
+    _log_dir = Path("/app/storage") if Path("/app/storage").exists() else Path(".")
+    _fh = logging.FileHandler(_log_dir / "api_errors.log", encoding="utf-8")
+    _fh.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+    _api_error_logger.addHandler(_fh)
+except Exception:
+    pass  # Fall back to root logger if file handler fails
+
 # Get MongoDB connection string from environment variable
 MONGO_URL = os.environ.get("MONGO_URL", "mongodb://localhost:27017")
 DB_NAME = os.environ.get("DB_NAME", "licitaciones_db")
@@ -220,14 +232,41 @@ async def startup_db_client():
     except Exception as e:
         logger.error(f"Failed to create indexes: {e}")
 
-    # Initialize and start scheduler automatically
+    # Initialize and start scheduler automatically.
+    # CRITICAL: With Gunicorn -w 2, BOTH workers run this startup event.
+    # Use a file lock to ensure only ONE worker starts the scheduler.
+    # This prevents double-execution of enrichment cron, scrapers, etc.
+    import fcntl
+    _scheduler_lock_file = None
+    _scheduler_acquired = False
+    try:
+        _scheduler_lock_file = open("/tmp/licitometro-scheduler.lock", "w")
+        fcntl.flock(_scheduler_lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        _scheduler_acquired = True
+        logger.info(f"Scheduler lock acquired by worker PID={os.getpid()}")
+    except (IOError, OSError):
+        logger.info(f"Scheduler lock NOT acquired by worker PID={os.getpid()} — another worker owns it")
+    except Exception as e:
+        logger.warning(f"Scheduler lock check failed: {e} — will start scheduler anyway")
+        _scheduler_acquired = True  # Fallback: start scheduler if lock mechanism fails
+
+    if _scheduler_acquired:
+        # Store lock file handle on app to prevent GC from closing it
+        app.state._scheduler_lock_file = _scheduler_lock_file
+    else:
+        if _scheduler_lock_file:
+            _scheduler_lock_file.close()
+
     try:
         from services.scheduler_service import get_scheduler_service
         scheduler_service = get_scheduler_service(database)
         await scheduler_service.initialize()
         await scheduler_service.load_and_schedule_scrapers()
-        scheduler_service.start()
-        logger.info("Scheduler initialized and started automatically")
+        if _scheduler_acquired:
+            scheduler_service.start()
+            logger.info("Scheduler initialized and started (this worker owns the scheduler lock)")
+        else:
+            logger.info("Scheduler initialized but NOT started (another worker owns the scheduler lock)")
 
         # Schedule daily storage cleanup at 3am
         from services.storage_cleanup_service import get_cleanup_service


### PR DESCRIPTION
Three root-cause fixes for the 500 error on /api/licitaciones/:

1. BSON serialization safety (db/models.py):
   - Add _bson_safe() recursive converter for nested dicts/lists
   - Handles ObjectId, Binary, Decimal128, UUID inside metadata,
     attached_files, workflow_history, etc. that FastAPI's
     jsonable_encoder can't serialize
   - Use mongo_id_to_str() instead of str() for _id (handles
     UUID Binary subtype 4 properly)
   - licitaciones_entity() now skips bad documents instead of
     crashing the entire response

2. Dual-scheduler prevention (server.py):
   - Gunicorn -w 2 caused BOTH workers to start APScheduler
   - Result: every cron job ran TWICE (enrichment, scrapers, etc.)
   - Fix: file lock ensures only one worker starts the scheduler
   - Other worker initializes services but doesn't start scheduler

3. Error logging + diagnostics (server.py, licitaciones.py):
   - Dedicated api_errors.log file handler (survives enrichment
     log flood that drowns stdout)
   - GET /api/licitaciones/debug-query endpoint: tests DB
     connection, serialization, and list query independently
   - Reports _id type, worker PID, and full tracebacks

https://claude.ai/code/session_01E8dBh651gPhPo8Z6PCsm2M