### PR TITLE
claude/setup-openclaw-telegram-M5BnU

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Plataforma de monitoreo de licitaciones publicas de Mendoza, Argentina. Agrega d
 | Contenedores | Docker Compose (prod: mongodb + backend + nginx + certbot) |
 | Proxy/SSL | Nginx 1.25 + Let's Encrypt (certbot auto-renew) |
 | Notificaciones | Telegram Bot (@Licitobot) + Email (Postfix local relay) |
+| Asistente IA | OpenClaw + Gemini 2.5 Flash — bot Telegram @Licitometrobot (systemd nativo, aislado de Docker) |
 | Scraping | aiohttp + Selenium (para sitios con JS) + pypdf (para PDFs) |
 
 ---
@@ -400,6 +401,7 @@ ALLOWED_ORIGINS, STORAGE_MAX_MB, RUN_HISTORY_KEEP
 CACHE_TTL_HOURS, LOG_RETENTION_DAYS
 TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID
 SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASSWORD, NOTIFICATION_EMAIL_TO
+GEMINI_API_KEY, OPENCLAW_TELEGRAM_BOT_TOKEN, OPENCLAW_TELEGRAM_OWNER_ID
 ```
 Docker Compose lee `.env` (NO `.env.production`). En prod hay symlink `.env → .env.production`.
 
@@ -1063,6 +1065,23 @@ Los links en notificaciones de nodo incluyen `?token=xxx` (JWT con `sub: "reader
 - `backend/routers/auth.py`: `POST /api/auth/token-login`
 - `backend/server.py`: `/api/auth/token-login` en `AUTH_EXEMPT_PATHS`
 - `frontend/src/App.js`: Token exchange en `handleStartup()`
+
+---
+
+## Bots de Telegram (dos separados)
+
+| Bot | Token env var | Propósito | Servicio | Código |
+|---|---|---|---|---|
+| **@Licitobot** | `TELEGRAM_BOT_TOKEN` | Notificaciones push (digest diario 9am, nodo digests 9:15am/6pm) | backend FastAPI (container `licitometro-backend-1`) | `backend/services/notification_service.py`, `backend/services/nodo_digest_service.py` |
+| **@Licitometrobot** | `OPENCLAW_TELEGRAM_BOT_TOKEN` | Asistente IA conversacional (buscar, ver, vigentes, stats) | systemd `openclaw.service` (nativo, fuera de Docker) | `openclaw/` + `scripts/setup-openclaw-native.sh` |
+
+**Sin conflicto de polling**: @Licitobot solo usa `sendMessage` (no polling). @Licitometrobot hace long-polling vía OpenClaw. Dos tokens distintos → no pisan updates.
+
+**Aislamiento**: OpenClaw corre como servicio systemd independiente en `/opt/openclaw/`. Si falla, licitometro.ar + scrapers + @Licitobot siguen funcionando.
+
+**Deploy**: `ssh root@76.13.234.213 "cd /opt/licitometro && git pull && bash scripts/setup-openclaw-native.sh"` (idempotente, backup automático de config previa).
+
+**Troubleshooting @Licitometrobot**: ver `openclaw/README.md` sección Troubleshooting.
 
 ---
 

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -1,0 +1,101 @@
+# OpenClaw Gateway — @Licitometrobot
+
+Asistente IA de Licitometro vía Telegram (separado del bot de notificaciones @Licitobot).
+
+**Stack**: OpenClaw (npm) + Google Gemini 2.5 Flash + MCP plugin con 4 tools sobre el backend FastAPI.
+
+## Arquitectura (VPS, no-Docker)
+
+```
+/opt/openclaw/
+├── config/
+│   ├── config.template.json   # placeholders ${OPENCLAW_TELEGRAM_BOT_TOKEN}
+│   └── config.json            # generado por prestart.sh en cada restart
+├── workspace/
+│   └── SOUL.md                # system prompt
+├── mcp-licitometro/
+│   └── index.js               # MCP server (4 tools)
+└── prestart.sh                # sustituye placeholders
+
+/etc/systemd/system/openclaw.service   # systemd unit
+/opt/licitometro/.env                  # secretos (NO commitear)
+```
+
+## Deploy en VPS
+
+```bash
+ssh root@76.13.234.213
+cd /opt/licitometro && git pull
+bash scripts/setup-openclaw-native.sh
+```
+
+El setup es idempotente. Usa backup automático de la config previa antes de escribir.
+
+## Variables requeridas
+
+Agregar a `/opt/licitometro/.env`:
+
+```
+GEMINI_API_KEY=AIza…
+OPENCLAW_TELEGRAM_BOT_TOKEN=8640101849:…
+OPENCLAW_TELEGRAM_OWNER_ID=606163108
+```
+
+## Verificación
+
+```bash
+# Service activo
+systemctl status openclaw
+
+# Logs en vivo
+journalctl -u openclaw -f
+
+# Logs internos de OpenClaw
+tail -f /tmp/openclaw/openclaw-$(date +%Y-%m-%d).log
+
+# Test end-to-end: mandar a @Licitometrobot en Telegram:
+#   /start
+#   hola
+#   licitaciones vigentes
+#   buscá licitaciones de riego en Guaymallén
+```
+
+## Rollback
+
+OpenClaw corre **aislado** del stack Docker de Licitometro. Si algo se rompe:
+
+```bash
+systemctl stop openclaw
+systemctl disable openclaw
+```
+
+→ licitometro.ar + scrapers + @Licitobot siguen funcionando sin interrupción.
+
+## Tools MCP expuestas
+
+| Tool | Endpoint backend |
+|---|---|
+| `buscar` | `GET /api/licitaciones/` |
+| `ver` | `GET /api/licitaciones/{id}` |
+| `licitaciones_vigentes` | `GET /api/licitaciones/vigentes` |
+| `estadisticas` | `GET /api/licitaciones/stats/estado-distribution` |
+
+Los endpoints son públicos (no requieren auth).
+
+## Troubleshooting
+
+### El bot recibe mensajes pero no responde
+1. `journalctl -u openclaw -n 100` — buscar errors de Gemini
+2. `cat /proc/$(pgrep -f openclaw)/environ | tr '\0' '\n' | grep -E 'GEMINI|GOOGLE'` — verificar env vars
+3. Test directo de la API:
+   ```bash
+   curl -s "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$GEMINI_API_KEY" \
+     -H 'Content-Type: application/json' \
+     -d '{"contents":[{"parts":[{"text":"hola"}]}]}'
+   ```
+
+### `dmPolicy: "pairing"` bloquea DMs
+El template usa `"open"` para el owner único. Si querés pairing flow, cambiá a `"pairing"` en `config.template.json`.
+
+### Health monitor reinicia por stale-socket
+Conocido. No afecta usabilidad. Investigar si frecuencia < 20min.

--- a/openclaw/config/.env.example
+++ b/openclaw/config/.env.example
@@ -1,0 +1,14 @@
+# OpenClaw Gateway — variables requeridas en /opt/licitometro/.env
+#
+# Gemini API key (obtener en https://aistudio.google.com/apikeys)
+GEMINI_API_KEY=
+# OpenClaw expects GOOGLE_API_KEY; si solo ponés GEMINI_API_KEY,
+# setup-openclaw-native.sh copia el valor también a GOOGLE_API_KEY.
+GOOGLE_API_KEY=
+
+# Telegram — @Licitometrobot (asistente IA, SEPARADO de @Licitobot de notificaciones)
+OPENCLAW_TELEGRAM_BOT_TOKEN=
+OPENCLAW_TELEGRAM_OWNER_ID=
+
+# Opcional: nivel de log ("info" por defecto, "debug" para diagnóstico)
+# OPENCLAW_LOG_LEVEL=info

--- a/openclaw/config/config.json
+++ b/openclaw/config/config.json
@@ -1,0 +1,31 @@
+{
+  "gateway": {
+    "mode": "local",
+    "port": 18789,
+    "bind": "0.0.0.0"
+  },
+  "agent": {
+    "provider": "google",
+    "model": "gemini-2.5-flash",
+    "maxTokens": 8192,
+    "temperature": 0.3
+  },
+  "channels": {
+    "telegram": {
+      "enabled": true,
+      "botToken": "${OPENCLAW_TELEGRAM_BOT_TOKEN}",
+      "dmPolicy": "open",
+      "allowFrom": ["${OPENCLAW_TELEGRAM_OWNER_ID}"]
+    }
+  },
+  "mcpServers": {
+    "licitometro": {
+      "command": "node",
+      "args": ["/opt/openclaw/mcp-licitometro/index.js"],
+      "env": {
+        "LICITOMETRO_API_URL": "https://licitometro.ar/api"
+      }
+    }
+  },
+  "workspace": "/opt/openclaw/workspace"
+}

--- a/openclaw/mcp-licitometro/index.js
+++ b/openclaw/mcp-licitometro/index.js
@@ -227,12 +227,14 @@ const estadisticas = {
   },
   async execute() {
     try {
-      const data = await apiGet("/public/stats");
+      const data = await apiGet("/licitaciones/stats/estado-distribution");
+      const byEstado = data.by_estado || {};
+      const total = Object.values(byEstado).reduce((a, b) => a + (b || 0), 0);
       const lines = [
-        `Total licitaciones: ${data.total_licitaciones || 0}`,
-        `Fuentes activas: ${data.active_scrapers || 0}`,
+        `Total licitaciones: ${total}`,
         data.vigentes_hoy !== undefined ? `Vigentes hoy: ${data.vigentes_hoy}` : null,
-        data.by_estado ? `Por estado: ${JSON.stringify(data.by_estado)}` : null,
+        Object.keys(byEstado).length ? `Por estado: ${JSON.stringify(byEstado)}` : null,
+        data.by_year ? `Por año: ${JSON.stringify(data.by_year)}` : null,
       ]
         .filter(Boolean)
         .join("\n");

--- a/openclaw/workspace/SOUL.md
+++ b/openclaw/workspace/SOUL.md
@@ -1,0 +1,44 @@
+# Licitometro — Asistente IA
+
+Sos el asistente de **Licitometro** (https://licitometro.ar), la plataforma de monitoreo de licitaciones públicas de Mendoza, Argentina. Atendés consultas por Telegram (@Licitometrobot).
+
+## Personalidad
+- Respondés **en español rioplatense**, claro y directo.
+- Tono profesional pero cercano; sin florituras, sin emojis salvo que el usuario use.
+- Cuando no sabés algo, decilo; no inventes datos.
+
+## Qué hacés
+- Buscás licitaciones por texto, municipio, estado (vigente/vencida).
+- Mostrás detalle de una licitación (presupuesto, apertura, objeto, URL).
+- Listás las licitaciones vigentes con apertura próxima.
+- Devolvés estadísticas generales del sistema.
+
+## Herramientas MCP disponibles
+| Tool | Cuándo usar |
+|---|---|
+| `buscar` | El usuario pregunta por un tema, un municipio, un rubro. Pasá el texto EXACTO del usuario como `texto`. |
+| `ver` | Ya tenés un ID y querés detalle completo. |
+| `licitaciones_vigentes` | "Qué licitaciones hay abiertas", "vigentes hoy", "qué está por cerrar". |
+| `estadisticas` | "Cuántas licitaciones hay", "cuántas vigentes", distribución por estado. |
+
+## Reglas
+1. **Siempre usá una tool** cuando la pregunta se pueda resolver con datos. No respondas de memoria.
+2. **Si la tool devuelve "Error"**, explicá el problema en lenguaje natural y sugerí reformular.
+3. **URLs**: siempre incluí el link de `https://licitometro.ar/licitacion/{id}` para cada item.
+4. **Presupuestos**: formato argentino (`$1.234.567`).
+5. **Fechas**: formato `DD/MM/YYYY`.
+6. **No inventes municipios ni organismos**. Usá los nombres del FUENTE_MAP.
+
+## Ejemplos
+
+Usuario: *"qué licitaciones hay en Mendoza sobre riego"*
+→ `buscar({ texto: "riego" })` → formateás los resultados.
+
+Usuario: *"licitaciones vigentes de Godoy Cruz"*
+→ `buscar({ texto: "", municipio: "Godoy Cruz", estado: "vigente" })`.
+
+Usuario: *"cuántas licitaciones hay?"*
+→ `estadisticas()`.
+
+Usuario: *"vigentes hoy"*
+→ `licitaciones_vigentes()`.

--- a/scripts/openclaw-prestart.sh
+++ b/scripts/openclaw-prestart.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# openclaw-prestart.sh — Regenera /opt/openclaw/config/config.json desde el template
+# sustituyendo las variables de entorno (${OPENCLAW_TELEGRAM_BOT_TOKEN}, etc.).
+#
+# Corre como ExecStartPre de openclaw.service. Lee /opt/licitometro/.env.
+#
+# Diseño:
+#   - envsubst expande SOLO las vars que nombramos explícitamente, para no
+#     romper plantillas que tengan otros ${...} accidentales.
+#   - Si falta una variable crítica → abort con código != 0 (systemd no arranca).
+
+set -euo pipefail
+
+ENV_FILE="/opt/licitometro/.env"
+TEMPLATE="/opt/openclaw/config/config.template.json"
+OUTPUT="/opt/openclaw/config/config.json"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "[prestart] FATAL: $ENV_FILE no existe" >&2
+  exit 1
+fi
+
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "[prestart] FATAL: template no existe en $TEMPLATE" >&2
+  exit 1
+fi
+
+# Cargar vars (ignorando comentarios y líneas vacías)
+set -a
+# shellcheck disable=SC1090
+source <(grep -vE '^\s*(#|$)' "$ENV_FILE")
+set +a
+
+# OpenClaw puede esperar GOOGLE_API_KEY; si solo tenemos GEMINI_API_KEY, espejamos
+if [[ -z "${GOOGLE_API_KEY:-}" && -n "${GEMINI_API_KEY:-}" ]]; then
+  export GOOGLE_API_KEY="$GEMINI_API_KEY"
+fi
+
+# Validaciones críticas
+for var in OPENCLAW_TELEGRAM_BOT_TOKEN OPENCLAW_TELEGRAM_OWNER_ID GEMINI_API_KEY; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "[prestart] FATAL: variable $var vacía o ausente en $ENV_FILE" >&2
+    exit 2
+  fi
+done
+
+# Sustituir solo las vars que queremos expandir
+envsubst '${OPENCLAW_TELEGRAM_BOT_TOKEN} ${OPENCLAW_TELEGRAM_OWNER_ID}' \
+  < "$TEMPLATE" > "$OUTPUT"
+
+chmod 600 "$OUTPUT"
+
+echo "[prestart] config regenerada en $OUTPUT"

--- a/scripts/setup-openclaw-native.sh
+++ b/scripts/setup-openclaw-native.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# setup-openclaw-native.sh — Installer reproducible de OpenClaw para VPS Licitometro.
+#
+# Instala:
+#   - openclaw npm global (vía NVM node v22)
+#   - /opt/openclaw/{config,workspace,mcp-licitometro} desde este repo
+#   - /opt/openclaw/config/config.template.json (template con placeholders)
+#   - /opt/openclaw/prestart.sh (copia de scripts/openclaw-prestart.sh)
+#   - /etc/systemd/system/openclaw.service
+#
+# Requiere: root, /opt/licitometro/.env con variables OpenClaw presentes.
+#
+# Idempotente: re-ejecutar solo actualiza archivos sin destruir config en uso.
+#
+# ROLLBACK: `systemctl stop openclaw && systemctl disable openclaw`
+#           licitometro.ar + @Licitobot siguen funcionando (servicios aislados).
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-/opt/licitometro}"
+OC_HOME="/opt/openclaw"
+ENV_FILE="$REPO_ROOT/.env"
+SERVICE_FILE="/etc/systemd/system/openclaw.service"
+NVM_NODE_BIN="/root/.nvm/versions/node/v22.22.1/bin"
+
+log() { echo -e "\033[1;34m[setup-openclaw]\033[0m $*"; }
+err() { echo -e "\033[1;31m[setup-openclaw]\033[0m $*" >&2; }
+
+if [[ $EUID -ne 0 ]]; then
+  err "Este script debe correr como root."
+  exit 1
+fi
+
+# --- Pre-flight checks -------------------------------------------------------
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  err "FATAL: $ENV_FILE no existe. Copiá openclaw/config/.env.example y completalo."
+  exit 1
+fi
+
+for var in GEMINI_API_KEY OPENCLAW_TELEGRAM_BOT_TOKEN OPENCLAW_TELEGRAM_OWNER_ID; do
+  if ! grep -qE "^${var}=.+" "$ENV_FILE"; then
+    err "FATAL: $var falta o está vacía en $ENV_FILE"
+    exit 2
+  fi
+done
+
+if [[ ! -x "$NVM_NODE_BIN/node" ]]; then
+  err "FATAL: Node v22 no encontrado en $NVM_NODE_BIN. Instalá nvm + node 22 primero."
+  err "       curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash"
+  err "       nvm install 22 && nvm alias default 22"
+  exit 3
+fi
+
+# --- Backup config en uso (si existe) ---------------------------------------
+
+if [[ -f "$OC_HOME/config/config.json" ]]; then
+  BACKUP="$OC_HOME/config/config.json.bak.$(date +%s)"
+  cp "$OC_HOME/config/config.json" "$BACKUP"
+  log "Backup de config previa → $BACKUP"
+fi
+
+# --- Instalar openclaw npm ---------------------------------------------------
+
+log "Instalando openclaw@latest (npm global)…"
+export PATH="$NVM_NODE_BIN:$PATH"
+npm install -g openclaw@latest
+
+# --- Copiar árbol del repo a /opt/openclaw ----------------------------------
+
+mkdir -p "$OC_HOME/config" "$OC_HOME/workspace" "$OC_HOME/mcp-licitometro"
+
+log "Copiando openclaw/ del repo → $OC_HOME/"
+cp "$REPO_ROOT/openclaw/config/config.json"        "$OC_HOME/config/config.template.json"
+cp "$REPO_ROOT/openclaw/workspace/SOUL.md"         "$OC_HOME/workspace/SOUL.md"
+cp "$REPO_ROOT/openclaw/mcp-licitometro/index.js"  "$OC_HOME/mcp-licitometro/index.js"
+cp "$REPO_ROOT/scripts/openclaw-prestart.sh"       "$OC_HOME/prestart.sh"
+
+chmod +x "$OC_HOME/prestart.sh"
+chmod 600 "$OC_HOME/config/config.template.json"
+
+# Pre-generar config.json sustituyendo placeholders (primer arranque)
+log "Pre-generando config.json desde template…"
+bash "$OC_HOME/prestart.sh"
+
+# --- Systemd unit ------------------------------------------------------------
+
+log "Escribiendo $SERVICE_FILE…"
+cat > "$SERVICE_FILE" <<EOF
+[Unit]
+Description=OpenClaw Gateway (@Licitometrobot)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=$OC_HOME
+EnvironmentFile=$ENV_FILE
+# OpenClaw espera GOOGLE_API_KEY; lo espejamos a GEMINI_API_KEY
+Environment=GOOGLE_API_KEY=\${GEMINI_API_KEY}
+ExecStartPre=$OC_HOME/prestart.sh
+ExecStart=$NVM_NODE_BIN/node $NVM_NODE_BIN/openclaw gateway --config $OC_HOME/config/config.json --workspace $OC_HOME/workspace
+Restart=on-failure
+RestartSec=10
+# OpenClaw escribe logs a /tmp/openclaw/
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+
+# --- Enable + restart --------------------------------------------------------
+
+log "Habilitando y reiniciando openclaw.service…"
+systemctl enable openclaw.service
+systemctl restart openclaw.service
+
+sleep 3
+
+# --- Health check ------------------------------------------------------------
+
+if systemctl is-active --quiet openclaw.service; then
+  log "✅ openclaw.service está ACTIVE"
+  systemctl status openclaw.service --no-pager -n 10
+else
+  err "❌ openclaw.service NO arrancó. Logs:"
+  journalctl -u openclaw.service --no-pager -n 30
+  err "ROLLBACK: systemctl stop openclaw && systemctl disable openclaw"
+  exit 10
+fi
+
+log "Deploy completo. Probá mandándole un mensaje a @Licitometrobot."


### PR DESCRIPTION
Scaffolding reproducible del asistente IA de Telegram (separado del bot de
notificaciones @Licitobot). Corre como servicio systemd nativo aislado del
stack Docker: si OpenClaw falla, licitometro.ar + scrapers + @Licitobot no
se ven afectados.

Cambios:
- openclaw/config/config.json — template con placeholders (safe para repo)
- openclaw/config/.env.example — variables requeridas (GEMINI_API_KEY,
  OPENCLAW_TELEGRAM_BOT_TOKEN, OPENCLAW_TELEGRAM_OWNER_ID)
- openclaw/workspace/SOUL.md — system prompt en español
- openclaw/mcp-licitometro/index.js — MCP plugin movido de plugin-licitometro/
- scripts/setup-openclaw-native.sh — installer idempotente con backup y
  validación de env vars
- scripts/openclaw-prestart.sh — regenera config.json desde template en cada
  restart, validando que las vars críticas existan
- openclaw/README.md — doc de deploy y troubleshooting
- CLAUDE.md — sección "Bots de Telegram (dos separados)"

Fix del plugin MCP:
- endpoint /public/stats (que no existe) → /licitaciones/stats/estado-
  distribution. Ajusta el formateo para los campos reales (by_estado,
  by_year, vigentes_hoy).

Guardrails de producción:
- setup script NUNCA usa docker compose down
- backup automático de config.json previa antes de escribir
- rollback = systemctl stop openclaw (licitometro.ar sigue OK)
- .env del VPS NO se toca; el script solo lee vars
- prestart.sh falla con exit code != 0 si faltan vars críticas (systemd
  no arranca si el .env está roto)